### PR TITLE
Fixes getting protocol version before checking if server version is known

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [common] Improve MinecraftVersion added known version (1.8 to 1.21.1) with protocol number and some helper methods
 - [commands] Add UUIDParser
 - [commands] Add GameMode parser with lazy mapping
+- [spigot] Fix getting protocol version before checking if server version is known
 
 ## 0.0.35
 - [spigot] **hotfix** Wrong package for `PlayerVisibilityController_1_8_R1`

--- a/common/src/main/java/net/apartium/cocoabeans/structs/MinecraftVersion.java
+++ b/common/src/main/java/net/apartium/cocoabeans/structs/MinecraftVersion.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Represents version in the game.
@@ -208,7 +209,7 @@ public record MinecraftVersion(
      */
     @ApiStatus.AvailableSince("0.0.36")
     public static MinecraftVersion getVersion(int major, int update, int minor) {
-        return getVersion(major, update, minor, -1);
+        return getVersion(major, update, minor, () -> -1);
     }
 
     /**
@@ -219,13 +220,13 @@ public record MinecraftVersion(
      * @return cached minecraft version or create a new one with desired protocol version
      */
     @ApiStatus.AvailableSince("0.0.36")
-    public static MinecraftVersion getVersion(int major, int update, int minor, int protocol) {
+    public static MinecraftVersion getVersion(int major, int update, int minor, Supplier<Integer> protocol) {
         for (MinecraftVersion version : KNOWN_VERSIONS) {
             if (version.major == major && version.update == update && version.minor == minor) {
                 return version;
             }
         }
-        return new MinecraftVersion(major, update, minor, protocol);
+        return new MinecraftVersion(major, update, minor, protocol.get());
     }
 
     /**

--- a/spigot/src/main/java/net/apartium/cocoabeans/spigot/ServerUtils.java
+++ b/spigot/src/main/java/net/apartium/cocoabeans/spigot/ServerUtils.java
@@ -47,7 +47,7 @@ public class ServerUtils {
         } else {
             String[] split = version.split("\\.");
             try {
-                return MinecraftVersion.getVersion(Integer.parseInt(split[0]), Integer.parseInt(split[1]), split.length == 2 ? 0 : Integer.parseInt(split[2]), getProtocolVersion());
+                return MinecraftVersion.getVersion(Integer.parseInt(split[0]), Integer.parseInt(split[1]), split.length == 2 ? 0 : Integer.parseInt(split[2]), ServerUtils::getProtocolVersion);
             } catch (NumberFormatException e) {
                 Bukkit.getLogger().log(Level.SEVERE, "An error occurred while parsing version string: " + version, e);
                 return MinecraftVersion.UNKNOWN;


### PR DESCRIPTION


<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] 🐞 Bug fix (fixes an issue)

### 📚 Description
Closes #195
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new `UUIDParser` and `GameMode parser` for enhanced command processing.
	- Added a `ValueRequirement` for commands to improve functionality.
	- Updated `MinecraftVersion` to include known versions and protocol numbers from 1.8 to 1.21.1.

- **Bug Fixes**
	- Resolved multiple issues related to player visibility and command reloads.

- **Documentation**
	- Enhanced documentation for various components, including command details and parsing methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->