### PR TITLE
[commands-spigot] Add GameModeParser to SPIGOT_PARSERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [spigot] Fix getting protocol version before checking if server version is known
 - [spigot] Add simple dependency injection capabilities to ListenerAutoRegistration
 - [commands] Add ParserAssertions class for parser testing
+- [commands-spigot] Add GameModeParser to `SpigotCommandManager.SPIGOT_PARSERS`
 
 ## 0.0.35
 - [spigot] **hotfix** Wrong package for `PlayerVisibilityController_1_8_R1`

--- a/commands/spigot-platform/src/main/java/net/apartium/cocoabeans/commands/spigot/SpigotCommandManager.java
+++ b/commands/spigot-platform/src/main/java/net/apartium/cocoabeans/commands/spigot/SpigotCommandManager.java
@@ -14,10 +14,7 @@ import net.apartium.cocoabeans.commands.*;
 import net.apartium.cocoabeans.commands.exception.ExceptionArgumentMapper;
 import net.apartium.cocoabeans.commands.parsers.ArgumentParser;
 import net.apartium.cocoabeans.commands.spigot.exception.SpigotExceptionArgumentMapper;
-import net.apartium.cocoabeans.commands.spigot.parsers.LocationParser;
-import net.apartium.cocoabeans.commands.spigot.parsers.MaterialParser;
-import net.apartium.cocoabeans.commands.spigot.parsers.OfflinePlayerParser;
-import net.apartium.cocoabeans.commands.spigot.parsers.PlayerParser;
+import net.apartium.cocoabeans.commands.spigot.parsers.*;
 import net.apartium.cocoabeans.commands.spigot.requirements.Permission;
 import net.apartium.cocoabeans.spigot.Commands;
 import org.bukkit.command.CommandSender;
@@ -37,7 +34,8 @@ public class SpigotCommandManager extends CommandManager {
             new PlayerParser(0),
             new OfflinePlayerParser(0),
             new MaterialParser(0),
-            new LocationParser(0)
+            new LocationParser(0),
+            new GameModeParser(0)
     );
 
     private final JavaPlugin plugin;


### PR DESCRIPTION


<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description
Closes #197
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for Minecraft versions 1.8 to 1.21.1 with improved protocol handling.
	- Introduced new parsers: `UUIDParser`, `GameModeParser`, and `ParserAssertions`.
	- Added `Rotation` and `Transform` classes for better command processing.
	- Implemented a visibility manager API and improved command argument handling.
  
- **Bug Fixes**
	- Resolved issues with hidden group updates and reload functionality.
	- Fixed tab completion duplication and case insensitivity for parsers.

- **Documentation**
	- Updated documentation for region boxes, transformations, and command details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->