### PR TITLE
[spigot] Avoid enchant name duplication with EnchantGlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## 0.0.37
+- [spigot] Improved namedSpaceKey's names for EnchantGlow, now won't collide with other plugins.
+
 ## 0.0.36
 - [common] Improve MinecraftVersion added known version (1.8 to 1.21.1) with protocol number and some helper methods
 - [commands] Add UUIDParser

--- a/spigot/spigot-1-20/src/main/java/net/apartium/cocoabeans/spigot/inventory/EnchantGlow_1_20_R1.java
+++ b/spigot/spigot-1-20/src/main/java/net/apartium/cocoabeans/spigot/inventory/EnchantGlow_1_20_R1.java
@@ -12,13 +12,14 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+import java.lang.reflect.Field;
 import java.util.Set;
 
 @ApiStatus.Internal
 public class EnchantGlow_1_20_R1 extends Enchantment {
 
     public static final NamespacedKey
-            ENCHANT_GLOW_KEY = new NamespacedKey(JavaPlugin.getProvidingPlugin(EnchantGlow.class), "glow");
+            ENCHANT_GLOW_KEY = new NamespacedKey(JavaPlugin.getProvidingPlugin(EnchantGlow.class), "cocoa_glow");
 
     public EnchantGlow_1_20_R1() {
         super(ENCHANT_GLOW_KEY);
@@ -55,7 +56,7 @@ public class EnchantGlow_1_20_R1 extends Enchantment {
 
     @Override
     public String getName() {
-        return "Glow";
+        return "CocoaGlow";
     }
 
     @Override

--- a/spigot/spigot-1-8/src/main/java/net/apartium/cocoabeans/spigot/inventory/EnchantGlow_1_8_R1.java
+++ b/spigot/spigot-1-8/src/main/java/net/apartium/cocoabeans/spigot/inventory/EnchantGlow_1_8_R1.java
@@ -34,7 +34,7 @@ public class EnchantGlow_1_8_R1 extends Enchantment {
 
     @Override
     public String getName() {
-        return "Glow";
+        return "CocoaGlow";
     }
 
     @Override


### PR DESCRIPTION
Closes #208
Fixes an issue that could result in no items given from some systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The enchantment name has been updated from "Glow" to "CocoaGlow" for better branding.
	- The enchantment key has been changed to "cocoa_glow," enhancing its identity in the game.
	- Improved command handling with a new `CommandLexer` interface for better command tokenization.

These changes will enhance user experience by providing a more distinct and recognizable enchantment while improving command functionality and reducing potential plugin interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->