### PR TITLE
[commands] Log Error for Non-Public SubCommand Methods and Variable Misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [commands-spigot] Add `WorldParser`
 - [commands] Fixes CompoundParser method access modifiers
 - [commands] Fixes MapBasedParser tabCompletion index
+- [commands] Added error logging for cases where subcommand methods are non-public or when variables are misused.
+- [commands] Added `MethodUtils#getAllMethods(Class)` for getting all methods of a class including inherited & public & non-public
   
 ## 0.0.37
 - [commands] Enhanced command handling with improved serialization of subcommands

--- a/commands/src/main/java/net/apartium/cocoabeans/commands/SimpleArgumentMapper.java
+++ b/commands/src/main/java/net/apartium/cocoabeans/commands/SimpleArgumentMapper.java
@@ -116,7 +116,13 @@ public class SimpleArgumentMapper implements ArgumentMapper {
             }
 
             int index = counterMap.computeIfAbsent(type, k -> 0);
-            ArgumentIndex<?> argumentIndex = resolveArgumentIndex(type, parameter.parameterName(), counterMap, resultMap, index);
+
+            ArgumentIndex<?> argumentIndex;
+            try {
+                argumentIndex = resolveArgumentIndex(type, parameter.parameterName(), counterMap, resultMap, index);
+            } catch (NoSuchElementException e) {
+                throw new NoSuchElementException("There is no argument for parameter " + parameter.parameterName() + " at index " + index + ".", e);
+            }
 
             if (optional)
                 argumentIndex = wrapInOptional(argumentIndex);

--- a/commands/src/test/java/net/apartium/cocoabeans/commands/GeneralCommandTest.java
+++ b/commands/src/test/java/net/apartium/cocoabeans/commands/GeneralCommandTest.java
@@ -731,13 +731,12 @@ public class  GeneralCommandTest extends CommandTestBase {
     void evilCommand() {
         assertThrowsExactly(IllegalArgumentException.class, () -> testCommandManager.addCommand(new EvilCommandTest()), "Couldn't resolve net.apartium.cocoabeans.commands.EvilCommandTest#evil parser: thebotgame");
         assertThrowsExactly(RuntimeException.class, () -> testCommandManager.addCommand(new NullCommandTest()), "Static method net.apartium.cocoabeans.commands.NullCommandTest#meow is not supported");
-        testCommandManager.addCommand(new AnotherEvilCommandTest());
-        evaluate("evil-brother", "private");
-        assertEquals(List.of("Invalid usage"), sender.getMessages());
+        assertThrowsExactly(RuntimeException.class, () -> testCommandManager.addCommand(new AnotherEvilCommandTest()));
 
         assertThrowsExactly(NoSuchElementException.class, () -> testCommandManager.addCommand(new MoreEvilCommand()));
 
         assertThrowsExactly(IllegalArgumentException.class, () -> testCommandManager.addCommand(new ThereAnotherEvilCommand()));
+        assertThrowsExactly(RuntimeException.class, () -> testCommandManager.addCommand(new TrustMeBroImPublicEvilCommand()));
     }
 
 

--- a/commands/src/test/java/net/apartium/cocoabeans/commands/TrustMeBroImPublicEvilCommand.java
+++ b/commands/src/test/java/net/apartium/cocoabeans/commands/TrustMeBroImPublicEvilCommand.java
@@ -1,0 +1,13 @@
+package net.apartium.cocoabeans.commands;
+
+import org.opentest4j.AssertionFailedError;
+
+@Command("trust-me-bro")
+public class TrustMeBroImPublicEvilCommand implements CommandNode {
+
+    @SubCommand("im-public")
+    private void imPublicEvilCommand(Sender sender) {
+        throw new AssertionFailedError("How did we get here");
+    }
+
+}

--- a/common/src/main/java/net/apartium/cocoabeans/reflect/MethodUtils.java
+++ b/common/src/main/java/net/apartium/cocoabeans/reflect/MethodUtils.java
@@ -21,9 +21,28 @@ import java.util.stream.Collectors;
 /**
  * Utilities to work with java Method class
  * @see Method
- * @author Voigon (Lior S.)
+ * @author Voigon (Lior S.), Thebotgame (Kfir b.)
  */
 public class MethodUtils {
+
+    /**
+     * Get all methods from given class
+     * by recursion getting declared methods from super class
+     *
+     * @param clazz class
+     * @return set consisting of all methods from given class including super class public & non-public methods
+     */
+    @ApiStatus.AvailableSince("0.0.38")
+    public static Set<Method> getAllMethods(Class<?> clazz) {
+        Set<Method> methods = new HashSet<>();
+
+        while (clazz != null && clazz != Object.class) {
+            methods.addAll(ReflectionCache.getDeclaredMethods(clazz).toList());
+            clazz = clazz.getSuperclass();
+        }
+
+        return methods;
+    }
 
     /**
      * Get declared methods from given class


### PR DESCRIPTION


<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation)
- [x] 🐞 Bug fix (fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (adds functionality)

### 📚 Description
Added `MethodUtils#getAllMethods(Class)` for getting all methods of a class including inherited & public & non-public
The reason for it
| Method                 | Public | Non-public | Inherited |
|------------------------|--------|------------|-----------|
| `getMethods()`         |  ✅      |         ❌          | ✅         |
| `getDeclaredMethods()` |  ✅      | ✅          | ❌         |
We need a method to get all of them

Fixes log issue add both log for only public method for `@SubCommand` and misused parameter throw more specific log 

Closes #226
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?
Unit testing
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.