### PR TITLE
Fixes bug with WorldParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 ## 0.0.39
 - [commands-spigot] Added `WorldParser` to SpigotParsers
+- [commands-spigot] Fixes `WorldParser` to support on legacy versions
 - [common] Bump Minecraft Version 1.21.2 - 1.21.5
 
 ## 0.0.38

--- a/commands/spigot-platform/src/main/java/net/apartium/cocoabeans/commands/spigot/parsers/WorldParser.java
+++ b/commands/spigot-platform/src/main/java/net/apartium/cocoabeans/commands/spigot/parsers/WorldParser.java
@@ -78,7 +78,7 @@ public class WorldParser extends MapBasedParser<World> {
     public Map<String, World> getMap() {
         return Bukkit.getWorlds()
                 .stream()
-                .collect(Collectors.toMap(World::getName, world -> world));
+                .collect(Collectors.toMap((w) -> w.getName(), world -> world));
     }
 
 }


### PR DESCRIPTION


<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] 🐞 Bug fix (fixes an issue)
### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
When `World::getName` is compiled it change it into `WorldInfo::getName` and this function isn't available in legacy version,
And has been switch into `(w) -> w.getName()`

Closes #245
### 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Compiling the code and check manually 
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved world data processing for enhanced compatibility on legacy systems.
- **Documentation**
	- Updated release notes to reflect the improvements in version 0.0.39.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->