### PR TITLE
Fix maven central job fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
     uses: ./.github/workflows/callable.maven.yml
     with:
       VERSION: ${{ github.event.inputs.name }}
-      IS_PROD: ${{ github.event.inputs.isProd }}
+      IS_PROD: "${{ github.event.inputs.isProd }}"
     secrets:
       OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
Fix a bug where maven central job was failing because the `IS_PROD` env var isnt a string 

Closes #292 