### PR TITLE
[state] Define flatMap behavior for null source values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 ## 0.0.49
+- [state] Define flatMap behavior for null source values
 - [common] Add BoxSurfaceIterator
 
 ## 0.0.48

--- a/Writerside/topics/flat-map-observable.md
+++ b/Writerside/topics/flat-map-observable.md
@@ -36,6 +36,7 @@ This pattern quickly becomes repetitive and error-prone.
 
 ## Usage
 The `flatMap` operator maps each value to an observable and **observes the latest one**.
+<tip>If the source value of the observable is null, the mapper will not be called and return null as well.</tip>
 
 ```java
 Observable<PlayerRank> rank = player.rankObservable();

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapObservable.java
@@ -1,5 +1,7 @@
 package net.apartium.cocoabeans.state;
 
+import org.jspecify.annotations.NonNull;
+
 import java.util.*;
 import java.util.function.Function;
 
@@ -14,11 +16,11 @@ import java.util.function.Function;
     private Observable<R> currentInner;
     private R currentValue;
 
-    private final Function<T, Observable<R>> mapper;
+    private final Function<@NonNull T, Observable<R>> mapper;
 
     private final Set<Observer> observers = Collections.newSetFromMap(new WeakHashMap<>());
 
-    public FlatMapObservable(Observable<T> base, Function<T, Observable<R>> mapper) {
+    public FlatMapObservable(Observable<T> base, Function<@NonNull T, Observable<R>> mapper) {
         this.base = base;
         this.base.observe(this);
 

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Observable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Observable.java
@@ -1,6 +1,7 @@
 package net.apartium.cocoabeans.state;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NonNull;
 
 import java.util.List;
 import java.util.Set;
@@ -335,13 +336,14 @@ public interface Observable<T> {
      * Maps this observable's value to another {@link Observable} and observes the latest one.
      * When the source value changes, the previous inner observable is unsubscribed and the
      * new one returned by the mapper is observed.
+     * If the source value of this observable is null, the mapper will not be called and return null as well.
      *
      * @param mapper function mapping the current value to an observable
      * @param <R> the mapped value type
      * @return an observable
      */
     @ApiStatus.AvailableSince("0.0.47")
-    default <R> Observable<R> flatMap(Function<T, Observable<R>> mapper) {
+    default <R> Observable<R> flatMap(Function<@NonNull T, Observable<R>> mapper) {
         return new FlatMapObservable<>(this, mapper);
     }
 

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/FlatMapObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/FlatMapObservableTest.java
@@ -4,6 +4,7 @@ import net.apartium.cocoabeans.structs.Entry;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -649,6 +650,25 @@ class FlatMapObservableTest {
 
         prefix.set(null);
         assertNull(observable.get());
+    }
+
+    @Test
+    void nullTest() {
+        MutableObservable<String> pointer = Observable.mutable(null);
+        Observable<String> mapped = pointer.flatMap(a -> Observable.immutable("test"));
+
+        assertNull(mapped.get());
+    }
+
+    @Test
+    void nullOptionalTest() {
+        MutableObservable<String> pointer = Observable.mutable(null);
+        Observable<String> mapped = pointer.map(Optional::ofNullable).flatMap(a -> Observable.immutable(a.orElse("test")));
+
+        assertEquals("test", mapped.get());
+        pointer.set("test2");
+
+        assertEquals("test2", mapped.get());
     }
 
 }


### PR DESCRIPTION
Closes #348

<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation)
- [ ] 🐞 Bug fix (fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description
Closes #348 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?
Add more unit test
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified flatMap behavior: when a source observable emits a null value, the mapper function is not invoked, and the resulting observable will also emit null.

* **Tests**
  * Added test coverage for null-handling scenarios in flatMap operations to verify expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->