### PR TITLE
[commands] Add CommandDocs annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 ## 0.0.49
+- [commands] Add CommandDocs annotations
 - [commands-spigot] Make `WorldParser` use `NoSuchWorldResponse` for missing worlds
 - [commands] Allow overriding `ContextualMapBasedParser` no-such-element response
 - [state] Define flatMap behavior for null source values

--- a/cocoa-beans-commands/src/main/java/net/apartium/cocoabeans/commands/CommandDocs.java
+++ b/cocoa-beans-commands/src/main/java/net/apartium/cocoabeans/commands/CommandDocs.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, Lior Slakman (me@voigon.dev), ALL RIGHTS RESERVED
+ * Do not use, copy, modify, and/or distribute this software without explicit permission from the
+ * rights holder. Reselling this product is not allowed. Transfer of the source code to any person
+ * or organization not explicitly approved by the rights holder via a license agreement is hereby forbidden.
+ */
+
+package net.apartium.cocoabeans.commands;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Contains annotation used to generate various means of docs and help menus for commands.
+ * By definition, the included annotations have no impact on the processing of the commands at runtime.
+ */
+@ApiStatus.AvailableSince("0.0.49")
+public class CommandDocs {
+
+    /**
+     * Indicates the section name of a command. Often overrides label
+     */
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Section {
+
+        /**
+         * {LABEL} would be replaced with the command name / alias
+         * @return section name
+         */
+        String value();
+
+    }
+
+    /**
+     * Hides the member from generated documentation, can be useful for fallback variants.
+     */
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Hidden {
+
+    }
+
+    /**
+     * Indicates which version introduced the command
+     */
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Since {
+
+        /**
+         * @return product version where the command was added
+         */
+        String value();
+
+    }
+
+}

--- a/cocoa-beans-commands/src/main/java/net/apartium/cocoabeans/commands/CommandDocs.java
+++ b/cocoa-beans-commands/src/main/java/net/apartium/cocoabeans/commands/CommandDocs.java
@@ -59,4 +59,6 @@ public class CommandDocs {
 
     }
 
+    private CommandDocs() {}
+
 }


### PR DESCRIPTION


<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation)
- [ ] 🐞 Bug fix (fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description
Add annotations useful for generating docs from the command definitions.
- Hidden
- Since
- Section

Closes #356
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?
Core go brrrrrr
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added annotation support for command documentation to enable improved help generation, selective visibility of commands, and version tracking for command introductions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->