### PR TITLE
[state] Improve type flexibility of `Observable.compound`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 ## 0.0.49
-- [state] Improved type flexibility of `Observable.compound` by allowing `List<? extends Observable<?>>`
+- [state] [state] Improve type flexibility of `Observable.compound`
 - [commands-spigot] Add `WorldTypeParser`
 - [commands] Add CommandDocs annotations
 - [commands-spigot] Make `WorldParser` use `NoSuchWorldResponse` for missing worlds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 ## 0.0.49
+- [state] Improved type flexibility of `Observable.compound` by allowing `List<? extends Observable<?>>`
 - [commands-spigot] Add `WorldTypeParser`
 - [commands] Add CommandDocs annotations
 - [commands-spigot] Make `WorldParser` use `NoSuchWorldResponse` for missing worlds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 ## 0.0.49
-- [state] [state] Improve type flexibility of `Observable.compound`
+- [state] Improve type flexibility of `Observable.compound`
 - [commands-spigot] Add `WorldTypeParser`
 - [commands] Add CommandDocs annotations
 - [commands-spigot] Make `WorldParser` use `NoSuchWorldResponse` for missing worlds

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Observable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Observable.java
@@ -87,7 +87,7 @@ public interface Observable<T> {
      * @return a new observable instance
      * @param <T> the type of the final value
      */
-    static <T> Observable<T> compound(Function<List<?>, T> function, List<Observable<?>> depends) {
+    static <T> Observable<T> compound(Function<List<?>, T> function, List<? extends Observable<?>> depends) {
         return new ObservableCompound<>(function, depends);
     }
 

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ObservableCompound.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ObservableCompound.java
@@ -18,7 +18,7 @@ public class ObservableCompound<T> implements Observable<T>, Observer {
 
     private T cachedValue;
 
-    public ObservableCompound(Function<List<?>, T> singularMapper, List<Observable<?>> list) {
+    public ObservableCompound(Function<List<?>, T> singularMapper, List<? extends Observable<?>> list) {
         this.singularMapper = singularMapper;
 
         for (Observable<?> state : list) {

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ObservableCompoundTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ObservableCompoundTest.java
@@ -1,0 +1,77 @@
+package net.apartium.cocoabeans.state;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ObservableCompoundTest {
+
+    enum TeamStatus {
+        ALIVE,
+        RESPAWNING
+    }
+
+    @Test
+    void compoundAcceptsListOfObservable() {
+        Observable<TeamStatus> status = Observable.immutable(TeamStatus.ALIVE);
+
+        Observable<Boolean> result = Observable.compound(
+                values -> values.stream()
+                        .map(TeamStatus.class::cast)
+                        .allMatch(s -> s != TeamStatus.RESPAWNING),
+                List.of(status)
+        );
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void compoundAcceptsListOfMutableObservableSubtype() {
+        MutableObservable<TeamStatus> status = Observable.mutable(TeamStatus.ALIVE);
+
+        Observable<Boolean> result = Observable.compound(
+                values -> values.stream()
+                        .map(TeamStatus.class::cast)
+                        .allMatch(s -> s != TeamStatus.RESPAWNING),
+                List.of(status)
+        );
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void compoundAcceptsStreamToListOfMutableObservableSubtype() {
+        List<MutableObservable<TeamStatus>> depends = List.of(
+                Observable.mutable(TeamStatus.ALIVE),
+                Observable.mutable(TeamStatus.ALIVE)
+        );
+
+        Observable<Boolean> result = Observable.compound(
+                values -> values.stream()
+                        .map(TeamStatus.class::cast)
+                        .allMatch(s -> s != TeamStatus.RESPAWNING),
+                depends
+        );
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void compoundComputesFalseWhenAnyTeamRespawning() {
+        List<MutableObservable<TeamStatus>> depends = List.of(
+                Observable.mutable(TeamStatus.ALIVE),
+                Observable.mutable(TeamStatus.RESPAWNING)
+        );
+
+        Observable<Boolean> result = Observable.compound(
+                values -> values.stream()
+                        .map(TeamStatus.class::cast)
+                        .allMatch(s -> s != TeamStatus.RESPAWNING),
+                depends
+        );
+
+        assertFalse(result.get());
+    }
+}

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ObservableCompoundTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ObservableCompoundTest.java
@@ -3,6 +3,7 @@ package net.apartium.cocoabeans.state;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -43,10 +44,12 @@ class ObservableCompoundTest {
 
     @Test
     void compoundAcceptsStreamToListOfMutableObservableSubtype() {
-        List<MutableObservable<TeamStatus>> depends = List.of(
-                Observable.mutable(TeamStatus.ALIVE),
-                Observable.mutable(TeamStatus.ALIVE)
-        );
+        List<MutableObservable<TeamStatus>> depends = Stream.of(
+                TeamStatus.ALIVE,
+                TeamStatus.ALIVE
+        )
+                .map(Observable::mutable)
+                .toList();
 
         Observable<Boolean> result = Observable.compound(
                 values -> values.stream()


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation)
- [x] 🐞 Bug fix (fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description
The current Observable.compound method requires a `List<Observable<?>>`, which prevents passing lists of observable subtypes such as `List<MutableObservable<T>>` due to generic invariance.

This change updates the method signature to `List<? extends Observable<?>>`, allowing callers to pass subtype lists without needing manual conversion or unsafe casting.

This improves API usability while preserving existing behavior.

What didn't work before
```java
        Observable<Boolean> allTeamsBedBroken = Observable.compound(
                teamsStatus -> teamsStatus.stream()
                        .allMatch(status -> status != TeamStatus.RESPAWNING),
                game.getTeams().stream()
                        .filter(team -> team.getDefinition() != definition)
                        .map(BedWarsTeam::getStatus)
                        .toList()
        );
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?
- Added unit tests covering:
  - Passing `List<Observable<?>>`
  - Passing `List<MutableObservable<T>>`
  -  Using stream-generated lists `(toList())`
 - Verified compilation succeeds for previously failing cases
 - Confirmed no runtime behavior changes

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Observable.compound now accepts more flexible list input types, improving compatibility when composing observables with different type hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->