### PR TITLE
[state] Collection manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 ## 0.0.50
+- [state] Ensure `CollectionObservable#filter` returns results in a consistent order
+- [state] Add `CollectionObservable#flatMapEach` for live per-element mapping to inner observables.
+- [state] Add `CollectionObservable#mapEach` for live per-element transformation of observable collections.
 - [spigot] Fix `VisibilityPlayer` returning stale refs during quit/rejoin by introducing `onQuit()`/`onJoin()` lifecycle methods
 - [spigot] Fix `SpigotViewerGroup` leaking disconnected `Player` references by using a `WeakHashMap`-backed observable set
 - [state] Fix `SetObservable` always using `Set::copyOf`, add `copyOf` and `createInitSet` factory overloads

--- a/Writerside/cb.tree
+++ b/Writerside/cb.tree
@@ -43,6 +43,8 @@
                 <toc-element topic="linked-list-observable.md"/>
             </toc-element>
             <toc-element topic="filtering-collection-observable.md"/>
+            <toc-element topic="mapping-collection-observable.md"/>
+            <toc-element topic="flat-mapping-collection-observable.md"/>
         </toc-element>
         <toc-element topic="observer.md"/>
         <toc-element topic="watcher.md"/>

--- a/Writerside/topics/collection-observable.md
+++ b/Writerside/topics/collection-observable.md
@@ -29,6 +29,8 @@ That's where `CollectionObservable` shines:
 ## Implementations
 - [](list-observable.md)
 - [](set-observable.md)
-- [](filtering-collection-observable.md)
 - [](queue-observable.md)
   - [](linked-list-observable.md)
+- [](filtering-collection-observable.md)
+- [](mapping-collection-observable.md)
+- [](flat-mapping-collection-observable.md)

--- a/Writerside/topics/filtering-collection-observable.md
+++ b/Writerside/topics/filtering-collection-observable.md
@@ -34,6 +34,7 @@ This is different from a simple `Predicate<E>` filter, because the membership of
   - `false`: element disappears from filtered view 
 
 ## Notes per collection type
+
 | Source                  | Result                  | Element duplication                                                                           |
 |-------------------------|-------------------------|------------------------------------------------------------------------------------------------|
 | `ListObservable<E>`     | `ListObservable<E>`     | Source order and **multiplicity preserved** — each occurrence is included/excluded independently |

--- a/Writerside/topics/filtering-collection-observable.md
+++ b/Writerside/topics/filtering-collection-observable.md
@@ -33,6 +33,17 @@ This is different from a simple `Predicate<E>` filter, because the membership of
   - `true`: element appears in filtered view
   - `false`: element disappears from filtered view 
 
+## Notes per collection type
+| Source                  | Result                  | Element duplication                                                                           |
+|-------------------------|-------------------------|------------------------------------------------------------------------------------------------|
+| `ListObservable<E>`     | `ListObservable<E>`     | Source order and **multiplicity preserved** — each occurrence is included/excluded independently |
+| `SetObservable<E>`      | `SetObservable<E>`      | The source already deduplicates by element                                                     |
+
+> **Subscription bookkeeping is deduped.** When several elements share the same
+> predicate observable (or one element appears multiple times), the predicate is
+> subscribed to **once**. A single change to that predicate updates every
+> matching occurrence in the filtered result.
+
 ## Advantages
 - **✅ Live subset view**: Always up-to-date without manual bookkeeping
 - **🧠 Reactive membership**: Elements can enter/leave the view when their internal state changes

--- a/Writerside/topics/flat-mapping-collection-observable.md
+++ b/Writerside/topics/flat-mapping-collection-observable.md
@@ -1,0 +1,55 @@
+# 🪐 Flat Mapping Collection Observable
+
+<sup>
+Available Since 0.0.50
+</sup>
+
+## Introduction
+`flatMapEach` is the per-element analogue of [](flat-map-observable.md) for collections.
+Each element of the source is mapped to an `Observable<R>`, and the derived collection
+contains the **current value of each element's observable**.
+
+Use this when the items in your collection expose **observable properties** —
+e.g. a player's display name or an entity's health — and you want a live view of
+one of those properties across the whole collection.
+
+```java
+ListObservable<DisplayPlayer> players = Observable.list();
+
+ListObservable<String> displayNames = players.flatMapEach(DisplayPlayer::displayName);
+// updates when:
+//   - players are added/removed
+//   - any tracked player's displayName changes
+```
+
+## Usage
+<code-block lang="java" src="state/CodeSnippets.java" include-symbol="flatMapEachSample"/>
+
+## Behavior
+- Subscribes to **each element's inner observable** while the element is present in the source.
+- When an element leaves the source, its inner subscription is released.
+- Multiple elements may share the same inner observable — it is observed **once**
+  and stays observed as long as **any** referencing element is still in the source.
+- The mapper is invoked at most once per element per source change, **not** on every inner-value update.
+- Cached: `get()` reuses the previous result until the source changes or a tracked inner observable changes.
+
+## Notes per collection type
+| Source                  | Result                  | Element duplication                                                                 |
+|-------------------------|-------------------------|--------------------------------------------------------------------------------------|
+| `ListObservable<E>`     | `ListObservable<R>`     | Order and **multiplicity preserved** — each occurrence resolves to its inner observable's current value |
+| `SetObservable<E>`      | `SetObservable<R>`      | The source already deduplicates by element                                           |
+
+> **Subscription bookkeeping is deduped.** Even when the same element appears
+> several times in a list, its inner observable is subscribed to **once**. A
+> single change to that inner observable then updates every occurrence of the
+> element in the mapped result.
+
+> The derived collection is **read-only**. `add`, `remove`, `addAll`, `removeAll`,
+> `removeIf`, `retainAll`, `clear` — and the list-specific `add(int, E)`,
+> `remove(int)`, `sort` — all throw `UnsupportedOperationException`.
+
+## Advantages
+- 👁 **Two-layer reactivity**: outer collection + inner observable properties
+- 🔒 **No observer leaks**: subscriptions are released when elements leave
+- 🤝 **Sharing-friendly**: elements sharing an inner observable share the subscription
+- ⛓ **Composable**: combines naturally with `filter` and `mapEach`

--- a/Writerside/topics/flat-mapping-collection-observable.md
+++ b/Writerside/topics/flat-mapping-collection-observable.md
@@ -34,6 +34,7 @@ ListObservable<String> displayNames = players.flatMapEach(DisplayPlayer::display
 - Cached: `get()` reuses the previous result until the source changes or a tracked inner observable changes.
 
 ## Notes per collection type
+
 | Source                  | Result                  | Element duplication                                                                 |
 |-------------------------|-------------------------|--------------------------------------------------------------------------------------|
 | `ListObservable<E>`     | `ListObservable<R>`     | Order and **multiplicity preserved** — each occurrence resolves to its inner observable's current value |

--- a/Writerside/topics/mapping-collection-observable.md
+++ b/Writerside/topics/mapping-collection-observable.md
@@ -33,6 +33,7 @@ If your mapper returns an `Observable<R>` you want to follow live, use [](flat-m
   - `mapEach` does **not** subscribe to anything inside the mapped values — only the source collection.
 
 ## Notes per collection type
+
 | Source                  | Result                  | Effect of duplicates                                  |
 |-------------------------|-------------------------|-------------------------------------------------------|
 | `ListObservable<E>`     | `ListObservable<R>`     | Order and duplicates preserved                        |

--- a/Writerside/topics/mapping-collection-observable.md
+++ b/Writerside/topics/mapping-collection-observable.md
@@ -1,0 +1,49 @@
+# 🪞 Mapping Collection Observable
+
+<sup>
+Available Since 0.0.50
+</sup>
+
+## Introduction
+`mapEach` is a **per-element** transformation operator on a `CollectionObservable`.
+It produces a derived collection whose elements come from applying a mapper to **each element** of the source.
+
+This is different from `Observable#map`, which transforms the *whole* collection
+into a single value. `mapEach` keeps the **collection-shape** and transforms only
+its elements:
+
+```java
+ListObservable<GamePlayer> players = Observable.list();
+
+ListObservable<String> names = players.mapEach(GamePlayer::name);
+```
+
+If your mapper returns an `Observable<R>` you want to follow live, use [](flat-mapping-collection-observable.md) instead.
+
+## Usage
+<code-block lang="java" src="state/CodeSnippets.java" include-symbol="mapEachSample"/>
+
+## Behavior
+- Type-preserving:
+  - `ListObservable<E>` → `ListObservable<R>`
+  - `SetObservable<E>` → `SetObservable<R>`
+- The mapper runs **lazily** on `get()`, only when the source has changed since the previous call.
+- The result is **cached** between calls; the mapper is **not** re-run for unrelated reads.
+- Updates fire when the source collection changes (add / remove / clear / reorder).
+  - `mapEach` does **not** subscribe to anything inside the mapped values — only the source collection.
+
+## Notes per collection type
+| Source                  | Result                  | Effect of duplicates                                  |
+|-------------------------|-------------------------|-------------------------------------------------------|
+| `ListObservable<E>`     | `ListObservable<R>`     | Order and duplicates preserved                        |
+| `SetObservable<E>`      | `SetObservable<R>`      | Mapped collisions deduplicate (set semantics)         |
+
+> The derived collection is **read-only**. `add`, `remove`, `addAll`, `removeAll`,
+> `removeIf`, `retainAll`, `clear` — and the list-specific `add(int, E)`,
+> `remove(int)`, `sort` — all throw `UnsupportedOperationException`.
+
+## Advantages
+- 🪶 **Cheap**: lazy + cached, mapper runs once per element per source change
+- 🧱 **Composable**: chains naturally with `filter` and `flatMapEach`
+- 🧹 **No leaks**: nothing else is observed; only the source collection
+- ⛓ **Type-preserving**: a mapped `ListObservable` stays a `ListObservable`

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AbstractCollectionObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AbstractCollectionObservable.java
@@ -135,4 +135,28 @@ import java.util.function.Predicate;
     protected abstract C createFilteredCollection(Collection<E> elements);
 
     protected abstract C createCollection(int initialCapacity);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> mapEach(Function<E, R> mapper) {
+        return new MapElementObservable<>(
+                this,
+                mapper,
+                elements -> (Collection<R>) createFilteredCollection((Collection<E>) elements),
+                size -> (Collection<R>) createCollection(size)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> flatMapEach(Function<E, Observable<R>> mapper) {
+        return new FlatMapElementObservable<>(
+                this,
+                mapper,
+                elements -> (Collection<R>) createFilteredCollection((Collection<E>) elements),
+                size -> (Collection<R>) createCollection(size)
+        );
+    }
+
+
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AbstractCollectionObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AbstractCollectionObservable.java
@@ -9,7 +9,6 @@ import java.util.WeakHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-
 @ApiStatus.Internal
 /* package-private */ abstract class AbstractCollectionObservable<E, C extends Collection<E>> implements CollectionObservable<E, C> {
 
@@ -143,7 +142,7 @@ import java.util.function.Predicate;
                 this,
                 mapper,
                 elements -> (Collection<R>) createFilteredCollection((Collection<E>) elements),
-                size -> (Collection<R>) createCollection(size)
+                initialCapacity -> (Collection<R>) createCollection(initialCapacity)
         );
     }
 
@@ -154,7 +153,7 @@ import java.util.function.Predicate;
                 this,
                 mapper,
                 elements -> (Collection<R>) createFilteredCollection((Collection<E>) elements),
-                size -> (Collection<R>) createCollection(size)
+                initialCapacity -> (Collection<R>) createCollection(initialCapacity)
         );
     }
 

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/CollectionObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/CollectionObservable.java
@@ -103,4 +103,26 @@ public interface CollectionObservable<E, C extends Collection<E>> extends Observ
         return this.filter(element -> mapper.apply(element).map(filter::test));
     }
 
+    /**
+     * Maps each element of this observable to a new value using the provided mapper function.
+     * @param mapper function to map each element to a new value
+     * @return new observable containing mapped elements
+     * @param <R> new value type
+     */
+    @ApiStatus.AvailableSince("0.0.50")
+    <R> CollectionObservable<R, ? extends Collection<R>> mapEach(Function<E, R> mapper);
+
+    /**
+     * Transforms each element of this observable using the provided mapping function into an {@link Observable}
+     * of type {@code R}, then flattens the results into a single {@link CollectionObservable}.
+     *
+     * @param <R> the type of the elements in the resulting observable.
+     * @param mapper a function that takes an element of type {@code E} as input and maps it to an {@link Observable}
+     *               of type {@code R}.
+     * @return a {@link CollectionObservable} containing the flattened results of applying the mapping function
+     *         to each element of the current observable.
+     */
+    @ApiStatus.AvailableSince("0.0.50")
+    <R> CollectionObservable<R, ? extends Collection<R>> flatMapEach(Function<E, Observable<R>> mapper);
+
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/DerivedListObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/DerivedListObservable.java
@@ -1,0 +1,19 @@
+package net.apartium.cocoabeans.state;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Comparator;
+
+@ApiStatus.Internal
+/* package-private */ interface DerivedListObservable<E> extends ListObservable<E> {
+
+    @Override
+    default void add(int index, E element) { throw ListChainHelpers.unsupportedAdd(); }
+
+    @Override
+    default E remove(int index) { throw ListChainHelpers.unsupportedRemove(); }
+
+    @Override
+    default void sort(Comparator<? super E> comparator) { throw ListChainHelpers.unsupportedSort(); }
+
+}

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
@@ -107,18 +107,20 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
     private boolean updateElements(Set<E> elements, Collection<E> newCollection, Observable<Boolean> observable) {
         boolean hasChange = false;
 
+        boolean value = observable.get();
         for (E element : elements) {
             boolean contains = newCollection.contains(element);
 
-            boolean value = observable.get();
             if (value) {
-                newCollection.add(element);
-                if (!contains)
+                if (!contains) {
+                    newCollection.add(element);
                     hasChange = true;
+                }
             } else {
-                newCollection.remove(element);
-                if (contains)
+                if (contains) {
+                    newCollection.remove(element);
                     hasChange = true;
+                }
             }
         }
 
@@ -127,8 +129,7 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
 
     private boolean updateFlagged(Collection<E> newCollection) {
         boolean hasChange = false;
-        if (cachedCollection != null)
-            newCollection.addAll(cachedCollection);
+        newCollection.addAll(cachedCollection);
 
         for (Observable<Boolean> observable : flagged) {
             Set<E> elements = dependsOn.get(observable);

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
@@ -26,11 +26,13 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
     protected final Function<Integer, ? extends Collection<E>> constructCollection;
 
     private boolean baseDirty = true;
-    private final Set<Observable<Boolean>> flagged = new HashSet<>();
+    private final Set<Observable<Boolean>> flagged = Collections.newSetFromMap(new IdentityHashMap<>());
 
-    private final Map<Observable<Boolean>, Boolean> cacheValueMap = new HashMap<>();
-    private final Map<Observable<Boolean>, Set<E>> dependsOn = new LinkedHashMap<>();
+    private final Map<Observable<Boolean>, Boolean> cacheValueMap = new IdentityHashMap<>();
+    private final Map<Observable<Boolean>, Set<E>> dependsOn = new IdentityHashMap<>();
+    private final Map<E, Observable<Boolean>> observableForElement = new IdentityHashMap<>();
 
+    private Collection<E> baseSnapshot;
 
     private final Observable<Integer> size;
     private C cachedCollection;
@@ -60,110 +62,79 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
     }
 
     private void checkAndUpdateBase() {
-        C newDepends = base.get();
-        Set<Observable<Boolean>> keep = Collections.newSetFromMap(new IdentityHashMap<>());
+        C newSource = base.get();
+        baseSnapshot = newSource;
 
-        for (E e : newDepends) {
-            Observable<Boolean> observable = filter.apply(e);
-            keep.add(observable);
+        Set<E> seenElements = Collections.newSetFromMap(new IdentityHashMap<>());
+        seenElements.addAll(newSource);
 
-            boolean prev = dependsOn.computeIfAbsent(observable, key -> new LinkedHashSet<>()).add(e);
-            if (prev)
-                observable.observe(this);
+        Iterator<Map.Entry<E, Observable<Boolean>>> elementIterator = observableForElement.entrySet().iterator();
+        while (elementIterator.hasNext()) {
+            Map.Entry<E, Observable<Boolean>> entry = elementIterator.next();
+            if (seenElements.contains(entry.getKey()))
+                continue;
+
+            removeElementDependency(entry.getKey(), entry.getValue());
+            elementIterator.remove();
         }
 
-        Iterator<Map.Entry<Observable<Boolean>, Set<E>>> it = dependsOn.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<Observable<Boolean>, Set<E>> entry = it.next();
-            if (!keep.contains(entry.getKey())) {
-                entry.getKey().removeObserver(this);
-                it.remove();
-            } else {
-                entry.getValue().removeIf(e -> !newDepends.contains(e));
-            }
+        for (E element : newSource) {
+            if (observableForElement.containsKey(element))
+                continue;
 
+            Observable<Boolean> observable = filter.apply(element);
+            observableForElement.put(element, observable);
+
+            Set<E> elements = dependsOn.computeIfAbsent(observable, key -> {
+                key.observe(this);
+                return Collections.newSetFromMap(new IdentityHashMap<>());
+            });
+            elements.add(element);
         }
-
-        cacheValueMap.clear();
-        flagged.clear();
 
         baseDirty = false;
     }
 
-    private boolean updateFromScratch(Collection<E> newCollection) {
-        for (Map.Entry<Observable<Boolean>, Set<E>> entry : dependsOn.entrySet()) {
-            Observable<Boolean> observable = entry.getKey();
-            boolean value = observable.get();
-            if (value)
-                newCollection.addAll(entry.getValue());
+    private void removeElementDependency(E element, Observable<Boolean> observable) {
+        Set<E> elements = dependsOn.get(observable);
+        if (elements == null)
+            return;
 
+        elements.remove(element);
+        if (!elements.isEmpty())
+            return;
 
-            cacheValueMap.put(observable, value);
-        }
-
-        return true;
+        observable.removeObserver(this);
+        dependsOn.remove(observable);
+        cacheValueMap.remove(observable);
+        flagged.remove(observable);
     }
 
-    private boolean updateElements(Set<E> elements, Collection<E> newCollection, Observable<Boolean> observable) {
-        boolean hasChange = false;
-
-        boolean value = observable.get();
-        for (E element : elements) {
-            boolean contains = newCollection.contains(element);
-
-            if (value) {
-                if (!contains) {
-                    newCollection.add(element);
-                    hasChange = true;
-                }
-            } else {
-                if (contains) {
-                    newCollection.remove(element);
-                    hasChange = true;
-                }
-            }
-        }
-
-        return hasChange;
-    }
-
-    private boolean updateFlagged(Collection<E> newCollection) {
-        boolean hasChange = false;
-        newCollection.addAll(cachedCollection);
-
-        for (Observable<Boolean> observable : flagged) {
-            Set<E> elements = dependsOn.get(observable);
-            hasChange |= updateElements(elements, newCollection, observable);
-        }
-
-        flagged.clear();
-        return hasChange;
-    }
-    
     public C get() {
-        if (!baseDirty && flagged.isEmpty())
+        if (!baseDirty && flagged.isEmpty() && cachedCollection != null)
             return cachedCollection;
-
 
         if (baseDirty)
             checkAndUpdateBase();
 
-        boolean hasChange = false;
-        Collection<E> newCollection = constructCollection.apply(dependsOn.size());
-        if (cacheValueMap.isEmpty()) {
-            hasChange = updateFromScratch(newCollection);
-        } else if (!flagged.isEmpty()) {
-            hasChange = updateFlagged(newCollection);
+        for (Observable<Boolean> observable : flagged)
+            cacheValueMap.put(observable, observable.get());
+        flagged.clear();
+
+        Collection<E> newCollection = constructCollection.apply(baseSnapshot.size());
+        for (E element : baseSnapshot) {
+            Observable<Boolean> observable = observableForElement.get(element);
+            Boolean value = cacheValueMap.get(observable);
+            if (value == null) {
+                value = observable.get();
+                cacheValueMap.put(observable, value);
+            }
+            if (value)
+                newCollection.add(element);
         }
 
-        if (!hasChange)
-            return cachedCollection;
-
-
-        C result = collectionMapper.apply(newCollection);
-        cachedCollection = result;
-
-        return result;
+        cachedCollection = collectionMapper.apply(newCollection);
+        return cachedCollection;
     }
 
     /**

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
@@ -29,7 +29,7 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
     private final Set<Observable<Boolean>> flagged = new HashSet<>();
 
     private final Map<Observable<Boolean>, Boolean> cacheValueMap = new HashMap<>();
-    private final Map<Observable<Boolean>, Set<E>> dependsOn = new IdentityHashMap<>();
+    private final Map<Observable<Boolean>, Set<E>> dependsOn = new LinkedHashMap<>();
 
 
     private final Observable<Integer> size;
@@ -220,4 +220,27 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
     public CollectionObservable<E, C> filter(Function<E, Observable<Boolean>> filter) {
         return new FilterObservable<>(this, filter, collectionMapper, constructCollection);
     }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> mapEach(Function<E, R> mapper) {
+        return new MapElementObservable<>(
+                this,
+                mapper,
+                (Function) collectionMapper,
+                (Function) constructCollection
+        );
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> flatMapEach(Function<E, Observable<R>> mapper) {
+        return new FlatMapElementObservable<>(
+                this,
+                mapper,
+                (Function) collectionMapper,
+                (Function) constructCollection
+        );
+    }
+
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
@@ -124,7 +124,7 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
         Collection<E> newCollection = constructCollection.apply(baseSnapshot.size());
         for (E element : baseSnapshot) {
             Observable<Boolean> observable = observableForElement.get(element);
-            Boolean value = cacheValueMap.computeIfAbsent(observable, key -> {
+            boolean value = cacheValueMap.computeIfAbsent(observable, key -> {
                 boolean initialValue = key.get();
                 cacheValueMap.put(key, initialValue);
                 return initialValue;

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FilterObservable.java
@@ -124,11 +124,12 @@ public class FilterObservable<E, C extends Collection<E>> implements CollectionO
         Collection<E> newCollection = constructCollection.apply(baseSnapshot.size());
         for (E element : baseSnapshot) {
             Observable<Boolean> observable = observableForElement.get(element);
-            Boolean value = cacheValueMap.get(observable);
-            if (value == null) {
-                value = observable.get();
-                cacheValueMap.put(observable, value);
-            }
+            Boolean value = cacheValueMap.computeIfAbsent(observable, key -> {
+                boolean initialValue = key.get();
+                cacheValueMap.put(key, initialValue);
+                return initialValue;
+            });
+
             if (value)
                 newCollection.add(element);
         }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
@@ -1,0 +1,213 @@
+package net.apartium.cocoabeans.state;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A specialized observable implementation that flattens elements of a source observable
+ * into a single collection, applying a provided mapping function to transform each element
+ * from the source into an observable of a target type.
+ * </p>
+ * The class also manages the dynamic updating of its internal collection whenever changes
+ * occur in the source observable or the nested observables it depends upon.
+ *
+ * @param <F> The type of elements in the source observable.
+ * @param <E> The type of elements in the resulting flattened collection.
+ * @param <C> The specific type of collection used to hold the flattened elements.
+ */
+@ApiStatus.AvailableSince("0.0.50")
+public class FlatMapElementObservable<F, E, C extends Collection<E>> implements CollectionObservable<E, C>, Observer {
+
+    private final Set<Observer> observers = Collections.newSetFromMap(new WeakHashMap<>());
+
+    private final Observable<? extends Collection<F>> base;
+
+    private final Function<F, Observable<E>> mapper;
+    protected final Function<Collection<E>, C> collectionMapper;
+    protected final Function<Integer, ? extends Collection<E>> constructCollection;
+
+    private final Map<F, Observable<E>> innerByElement = new LinkedHashMap<>();
+    private final Map<Observable<E>, Set<F>> dependsOn = new IdentityHashMap<>();
+
+    private boolean baseDirty = true;
+    private boolean innerDirty = true;
+
+    private C cachedCollection;
+
+    private final Observable<Integer> size;
+
+    public FlatMapElementObservable(
+            Observable<? extends Collection<F>> base,
+            Function<F, Observable<E>> mapper,
+            Function<Collection<E>, C> collectionMapper,
+            Function<Integer, ? extends Collection<E>> constructCollection
+    ) {
+        this.base = base;
+        this.base.observe(this);
+
+        this.mapper = mapper;
+        this.collectionMapper = collectionMapper;
+        this.constructCollection = constructCollection;
+
+        this.size = this.map(Collection::size);
+    }
+
+    private void updateBase() {
+        if (!baseDirty)
+            return;
+
+        Collection<F> source = base.get();
+
+        Set<F> keepElements = Collections.newSetFromMap(new IdentityHashMap<>());
+        keepElements.addAll(source);
+
+        Iterator<Map.Entry<F, Observable<E>>> elementIterator = innerByElement.entrySet().iterator();
+        while (elementIterator.hasNext()) {
+            Map.Entry<F, Observable<E>> entry = elementIterator.next();
+
+            if (keepElements.contains(entry.getKey()))
+                continue;
+
+            removeInnerDependency(entry.getKey(), entry.getValue());
+            elementIterator.remove();
+        }
+
+        for (F element : source) {
+            if (innerByElement.containsKey(element))
+                continue;
+
+            Observable<E> inner = mapper.apply(element);
+            innerByElement.put(element, inner);
+
+            if (inner != null) {
+                Set<F> elements = dependsOn.computeIfAbsent(inner, key -> {
+                    key.observe(this);
+                    return Collections.newSetFromMap(new IdentityHashMap<>());
+                });
+
+                elements.add(element);
+            }
+        }
+
+        baseDirty = false;
+        innerDirty = true;
+    }
+
+    private void removeInnerDependency(F element, Observable<E> inner) {
+        if (inner == null)
+            return;
+
+        Set<F> elements = dependsOn.get(inner);
+        if (elements == null)
+            return;
+
+        elements.remove(element);
+
+        if (!elements.isEmpty())
+            return;
+
+        inner.removeObserver(this);
+        dependsOn.remove(inner);
+    }
+
+    @Override
+    public C get() {
+        if (!baseDirty && !innerDirty)
+            return cachedCollection;
+
+        updateBase();
+
+        Collection<E> mapped = constructCollection.apply(innerByElement.size());
+
+        for (Observable<E> observable : innerByElement.values()) {
+            if (observable == null)
+                mapped.add(null);
+            else
+                mapped.add(observable.get());
+        }
+
+        cachedCollection = collectionMapper.apply(mapped);
+        innerDirty = false;
+
+        return cachedCollection;
+    }
+
+    protected void notifyObservers() {
+        for (Observer observer : observers)
+            observer.flagAsDirty(this);
+    }
+
+    @Override
+    public void flagAsDirty(Observable<?> observable) {
+        if (observable == base) {
+            baseDirty = true;
+            notifyObservers();
+            return;
+        }
+
+        if (dependsOn.containsKey(observable)) {
+            innerDirty = true;
+            notifyObservers();
+        }
+    }
+
+    @Override
+    public void observe(Observer observer) {
+        observers.add(observer);
+    }
+
+    @Override
+    public boolean removeObserver(Observer observer) {
+        return observers.remove(observer);
+    }
+
+    @Override public boolean add(E element) { throw new UnsupportedOperationException("FlatMapElementObservable does not support adding elements"); }
+
+    @Override public boolean remove(E element) { throw new UnsupportedOperationException("FlatMapElementObservable does not support removing elements"); }
+
+    @Override public boolean addAll(Collection<? extends E> collection) { throw new UnsupportedOperationException("FlatMapElementObservable does not support adding elements"); }
+
+    @Override public boolean removeAll(Collection<? extends E> collection) { throw new UnsupportedOperationException("FlatMapElementObservable does not support removing elements"); }
+
+    @Override public boolean removeIf(Predicate<? super E> filter) { throw new UnsupportedOperationException("FlatMapElementObservable does not support removing elements"); }
+
+    @Override public boolean retainAll(Collection<? extends E> collection) { throw new UnsupportedOperationException("FlatMapElementObservable does not support removing elements"); }
+
+    @Override public void clear() { throw new UnsupportedOperationException("FlatMapElementObservable does not support removing elements"); }
+
+    @Override
+    public Observable<Integer> size() {
+        return size;
+    }
+
+    @Override
+    public CollectionObservable<E, C> filter(Function<E, Observable<Boolean>> filter) {
+        return new FilterObservable<>(this, filter, collectionMapper, constructCollection);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> mapEach(Function<E, R> mapper) {
+        return new MapElementObservable<>(
+                this,
+                mapper,
+                (Function) collectionMapper,
+                (Function) constructCollection
+        );
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> flatMapEach(Function<E, Observable<R>> mapper) {
+        return new FlatMapElementObservable<>(
+                this,
+                mapper,
+                (Function) collectionMapper,
+                (Function) constructCollection
+        );
+    }
+
+}

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
@@ -29,7 +29,7 @@ public class FlatMapElementObservable<F, E, C extends Collection<E>> implements 
     protected final Function<Collection<E>, C> collectionMapper;
     protected final Function<Integer, ? extends Collection<E>> constructCollection;
 
-    private final Map<F, Observable<E>> innerByElement = new LinkedHashMap<>();
+    private final Map<F, Observable<E>> innerByElement = new IdentityHashMap<>();
     private final Map<Observable<E>, Set<F>> dependsOn = new IdentityHashMap<>();
 
     private boolean baseDirty = true;
@@ -124,13 +124,23 @@ public class FlatMapElementObservable<F, E, C extends Collection<E>> implements 
         updateBase();
 
         Collection<E> mapped = constructCollection.apply(lastSource.size());
+        Map<Observable<E>, E> innerValues = new IdentityHashMap<>();
 
         for (F element : lastSource) {
             Observable<E> observable = innerByElement.get(element);
-            if (observable == null)
+            if (observable == null) {
                 mapped.add(null);
-            else
-                mapped.add(observable.get());
+                continue;
+            }
+
+            E value;
+            if (innerValues.containsKey(observable)) {
+                value = innerValues.get(observable);
+            } else {
+                value = observable.get();
+                innerValues.put(observable, value);
+            }
+            mapped.add(value);
         }
 
         cachedCollection = collectionMapper.apply(mapped);

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
@@ -35,6 +35,8 @@ public class FlatMapElementObservable<F, E, C extends Collection<E>> implements 
     private boolean baseDirty = true;
     private boolean innerDirty = true;
 
+    private Collection<F> lastSource;
+
     private C cachedCollection;
 
     private final Observable<Integer> size;
@@ -60,6 +62,7 @@ public class FlatMapElementObservable<F, E, C extends Collection<E>> implements 
             return;
 
         Collection<F> source = base.get();
+        this.lastSource = source;
 
         Set<F> keepElements = Collections.newSetFromMap(new IdentityHashMap<>());
         keepElements.addAll(source);
@@ -120,9 +123,10 @@ public class FlatMapElementObservable<F, E, C extends Collection<E>> implements 
 
         updateBase();
 
-        Collection<E> mapped = constructCollection.apply(innerByElement.size());
+        Collection<E> mapped = constructCollection.apply(lastSource.size());
 
-        for (Observable<E> observable : innerByElement.values()) {
+        for (F element : lastSource) {
+            Observable<E> observable = innerByElement.get(element);
             if (observable == null)
                 mapped.add(null);
             else

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/FlatMapElementObservable.java
@@ -10,7 +10,7 @@ import java.util.function.Predicate;
  * A specialized observable implementation that flattens elements of a source observable
  * into a single collection, applying a provided mapping function to transform each element
  * from the source into an observable of a target type.
- * </p>
+ * <p>
  * The class also manages the dynamic updating of its internal collection whenever changes
  * occur in the source observable or the nested observables it depends upon.
  *

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListChainHelpers.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListChainHelpers.java
@@ -1,0 +1,63 @@
+package net.apartium.cocoabeans.state;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+@ApiStatus.Internal
+/* package-private */ final class ListChainHelpers {
+
+    private static final String NO_ADD = "ListObservable derived view does not support adding elements";
+    private static final String NO_REMOVE = "ListObservable derived view does not support removing elements";
+    private static final String NO_SORT = "ListObservable derived view does not support sorting";
+
+    private ListChainHelpers() {}
+
+    static UnsupportedOperationException unsupportedAdd() {
+        return new UnsupportedOperationException(NO_ADD);
+    }
+
+    static UnsupportedOperationException unsupportedRemove() {
+        return new UnsupportedOperationException(NO_REMOVE);
+    }
+
+    static UnsupportedOperationException unsupportedSort() {
+        return new UnsupportedOperationException(NO_SORT);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static <F, R, E> ListObservable<R> mapEach(
+            Observable<? extends Collection<F>> base,
+            Function<F, R> mapper,
+            Function<Collection<E>, List<E>> collectionMapper,
+            Function<Integer, ? extends Collection<E>> constructCollection
+    ) {
+        return new ListMapEachObservable<>(base, mapper, (Function) collectionMapper, (Function) constructCollection);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static <F, R, E> ListObservable<R> flatMapEach(
+            Observable<? extends Collection<F>> base,
+            Function<F, Observable<R>> mapper,
+            Function<Collection<E>, List<E>> collectionMapper,
+            Function<Integer, ? extends Collection<E>> constructCollection
+    ) {
+        return new ListFlatMapEachObservable<>(base, mapper, (Function) collectionMapper, (Function) constructCollection);
+    }
+
+    static <E> ListObservable<E> filter(Observable<List<E>> base, Function<E, Observable<Boolean>> filter) {
+        return new ListFilterObservable<>(base, filter);
+    }
+
+    static <E, T> ListObservable<E> filter(
+            Observable<List<E>> base,
+            Function<E, Observable<T>> mapper,
+            Predicate<T> filter
+    ) {
+        return filter(base, element -> mapper.apply(element).map(filter::test));
+    }
+
+}

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFilterObservable.java
@@ -1,50 +1,41 @@
 package net.apartium.cocoabeans.state;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+@ApiStatus.Internal
 /* package-private */ class ListFilterObservable<E> extends FilterObservable<E, List<E>> implements ListObservable<E> {
 
     public ListFilterObservable(Observable<List<E>> base, Function<E, Observable<Boolean>> filter) {
         super(base, filter, List::copyOf, ArrayList::new);
     }
 
-    @Override public void add(int index, E element) { throw new UnsupportedOperationException("ListFilterObservable does not support adding elements"); }
-    @Override public E remove(int index) { throw new UnsupportedOperationException("ListFilterObservable does not support removing elements"); }
-    @Override public void sort(Comparator<? super E> comparator) { throw new UnsupportedOperationException("ListFilterObservable does not support sorting"); }
+    @Override public void add(int index, E element) { throw ListChainHelpers.unsupportedAdd(); }
+    @Override public E remove(int index) { throw ListChainHelpers.unsupportedRemove(); }
+    @Override public void sort(Comparator<? super E> comparator) { throw ListChainHelpers.unsupportedSort(); }
 
     @Override
     public ListObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new ListFilterObservable<>(this, filter);
+        return ListChainHelpers.filter(this, filter);
     }
 
     @Override
     public <T> ListObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return ListChainHelpers.filter(this, mapper, filter);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> ListObservable<R> mapEach(Function<E, R> mapper) {
-        return new ListMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return ListChainHelpers.mapEach(this, mapper, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> ListObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new ListFlatMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return ListChainHelpers.flatMapEach(this, mapper, collectionMapper, constructCollection);
     }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFilterObservable.java
@@ -1,7 +1,6 @@
 package net.apartium.cocoabeans.state;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFilterObservable.java
@@ -3,21 +3,16 @@ package net.apartium.cocoabeans.state;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 @ApiStatus.Internal
-/* package-private */ class ListFilterObservable<E> extends FilterObservable<E, List<E>> implements ListObservable<E> {
+/* package-private */ class ListFilterObservable<E> extends FilterObservable<E, List<E>> implements DerivedListObservable<E> {
 
     public ListFilterObservable(Observable<List<E>> base, Function<E, Observable<Boolean>> filter) {
         super(base, filter, List::copyOf, ArrayList::new);
     }
-
-    @Override public void add(int index, E element) { throw ListChainHelpers.unsupportedAdd(); }
-    @Override public E remove(int index) { throw ListChainHelpers.unsupportedRemove(); }
-    @Override public void sort(Comparator<? super E> comparator) { throw ListChainHelpers.unsupportedSort(); }
 
     @Override
     public ListObservable<E> filter(Function<E, Observable<Boolean>> filter) {

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFlatMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFlatMapEachObservable.java
@@ -1,16 +1,15 @@
 package net.apartium.cocoabeans.state;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/* package-private */ class ListFilterObservable<E> extends FilterObservable<E, List<E>> implements ListObservable<E> {
+/* package-private */ class ListFlatMapEachObservable<F, E> extends FlatMapElementObservable<F, E, List<E>> implements ListObservable<E> {
 
-    public ListFilterObservable(Observable<List<E>> base, Function<E, Observable<Boolean>> filter) {
-        super(base, filter, List::copyOf, ArrayList::new);
+    public ListFlatMapEachObservable(Observable<? extends Collection<F>> base, Function<F, Observable<E>> mapper, Function<Collection<E>, List<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
+        super(base, mapper, collectionMapper, constructCollection);
     }
 
     @Override public void add(int index, E element) { throw new UnsupportedOperationException("ListFilterObservable does not support adding elements"); }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFlatMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFlatMapEachObservable.java
@@ -1,50 +1,41 @@
 package net.apartium.cocoabeans.state;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+@ApiStatus.Internal
 /* package-private */ class ListFlatMapEachObservable<F, E> extends FlatMapElementObservable<F, E, List<E>> implements ListObservable<E> {
 
     public ListFlatMapEachObservable(Observable<? extends Collection<F>> base, Function<F, Observable<E>> mapper, Function<Collection<E>, List<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
         super(base, mapper, collectionMapper, constructCollection);
     }
 
-    @Override public void add(int index, E element) { throw new UnsupportedOperationException("ListFilterObservable does not support adding elements"); }
-    @Override public E remove(int index) { throw new UnsupportedOperationException("ListFilterObservable does not support removing elements"); }
-    @Override public void sort(Comparator<? super E> comparator) { throw new UnsupportedOperationException("ListFilterObservable does not support sorting"); }
+    @Override public void add(int index, E element) { throw ListChainHelpers.unsupportedAdd(); }
+    @Override public E remove(int index) { throw ListChainHelpers.unsupportedRemove(); }
+    @Override public void sort(Comparator<? super E> comparator) { throw ListChainHelpers.unsupportedSort(); }
 
     @Override
     public ListObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new ListFilterObservable<>(this, filter);
+        return ListChainHelpers.filter(this, filter);
     }
 
     @Override
     public <T> ListObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return ListChainHelpers.filter(this, mapper, filter);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> ListObservable<R> mapEach(Function<E, R> mapper) {
-        return new ListMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return ListChainHelpers.mapEach(this, mapper, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> ListObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new ListFlatMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return ListChainHelpers.flatMapEach(this, mapper, collectionMapper, constructCollection);
     }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFlatMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListFlatMapEachObservable.java
@@ -3,21 +3,16 @@ package net.apartium.cocoabeans.state;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 @ApiStatus.Internal
-/* package-private */ class ListFlatMapEachObservable<F, E> extends FlatMapElementObservable<F, E, List<E>> implements ListObservable<E> {
+/* package-private */ class ListFlatMapEachObservable<F, E> extends FlatMapElementObservable<F, E, List<E>> implements DerivedListObservable<E> {
 
     public ListFlatMapEachObservable(Observable<? extends Collection<F>> base, Function<F, Observable<E>> mapper, Function<Collection<E>, List<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
         super(base, mapper, collectionMapper, constructCollection);
     }
-
-    @Override public void add(int index, E element) { throw ListChainHelpers.unsupportedAdd(); }
-    @Override public E remove(int index) { throw ListChainHelpers.unsupportedRemove(); }
-    @Override public void sort(Comparator<? super E> comparator) { throw ListChainHelpers.unsupportedSort(); }
 
     @Override
     public ListObservable<E> filter(Function<E, Observable<Boolean>> filter) {

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListMapEachObservable.java
@@ -1,16 +1,13 @@
 package net.apartium.cocoabeans.state;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/* package-private */ class ListFilterObservable<E> extends FilterObservable<E, List<E>> implements ListObservable<E> {
+/* package-private */ class ListMapEachObservable<F, E> extends MapElementObservable<F, E, List<E>> implements ListObservable<E> {
 
-    public ListFilterObservable(Observable<List<E>> base, Function<E, Observable<Boolean>> filter) {
-        super(base, filter, List::copyOf, ArrayList::new);
+    public ListMapEachObservable(Observable<? extends Collection<F>> base, Function<F, E> mapper, Function<Collection<E>, List<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
+        super(base, mapper, collectionMapper, constructCollection);
     }
 
     @Override public void add(int index, E element) { throw new UnsupportedOperationException("ListFilterObservable does not support adding elements"); }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListMapEachObservable.java
@@ -1,48 +1,39 @@
 package net.apartium.cocoabeans.state;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+@ApiStatus.Internal
 /* package-private */ class ListMapEachObservable<F, E> extends MapElementObservable<F, E, List<E>> implements ListObservable<E> {
 
     public ListMapEachObservable(Observable<? extends Collection<F>> base, Function<F, E> mapper, Function<Collection<E>, List<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
         super(base, mapper, collectionMapper, constructCollection);
     }
 
-    @Override public void add(int index, E element) { throw new UnsupportedOperationException("ListFilterObservable does not support adding elements"); }
-    @Override public E remove(int index) { throw new UnsupportedOperationException("ListFilterObservable does not support removing elements"); }
-    @Override public void sort(Comparator<? super E> comparator) { throw new UnsupportedOperationException("ListFilterObservable does not support sorting"); }
+    @Override public void add(int index, E element) { throw ListChainHelpers.unsupportedAdd(); }
+    @Override public E remove(int index) { throw ListChainHelpers.unsupportedRemove(); }
+    @Override public void sort(Comparator<? super E> comparator) { throw ListChainHelpers.unsupportedSort(); }
 
     @Override
     public ListObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new ListFilterObservable<>(this, filter);
+        return ListChainHelpers.filter(this, filter);
     }
 
     @Override
     public <T> ListObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return ListChainHelpers.filter(this, mapper, filter);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> ListObservable<R> mapEach(Function<E, R> mapper) {
-        return new ListMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return ListChainHelpers.mapEach(this, mapper, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> ListObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new ListFlatMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return ListChainHelpers.flatMapEach(this, mapper, collectionMapper, constructCollection);
     }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListMapEachObservable.java
@@ -7,15 +7,11 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 @ApiStatus.Internal
-/* package-private */ class ListMapEachObservable<F, E> extends MapElementObservable<F, E, List<E>> implements ListObservable<E> {
+/* package-private */ class ListMapEachObservable<F, E> extends MapElementObservable<F, E, List<E>> implements DerivedListObservable<E> {
 
     public ListMapEachObservable(Observable<? extends Collection<F>> base, Function<F, E> mapper, Function<Collection<E>, List<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
         super(base, mapper, collectionMapper, constructCollection);
     }
-
-    @Override public void add(int index, E element) { throw ListChainHelpers.unsupportedAdd(); }
-    @Override public E remove(int index) { throw ListChainHelpers.unsupportedRemove(); }
-    @Override public void sort(Comparator<? super E> comparator) { throw ListChainHelpers.unsupportedSort(); }
 
     @Override
     public ListObservable<E> filter(Function<E, Observable<Boolean>> filter) {

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservable.java
@@ -2,6 +2,7 @@ package net.apartium.cocoabeans.state;
 
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -20,4 +21,12 @@ public interface ListObservable<E> extends CollectionObservable<E, List<E>>, Lis
 
     @Override
     <T> ListObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter);
+
+    @ApiStatus.AvailableSince("0.0.50")
+    @Override
+    <R> ListObservable<R> mapEach(Function<E, R> mapper);
+
+    @ApiStatus.AvailableSince("0.0.50")
+    @Override
+    <R> ListObservable<R> flatMapEach(Function<E, Observable<R>> mapper);
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservable.java
@@ -2,7 +2,6 @@ package net.apartium.cocoabeans.state;
 
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservableImpl.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservableImpl.java
@@ -83,4 +83,23 @@ import java.util.function.Predicate;
         return this.filter(element -> mapper.apply(element).map(filter::test));
     }
 
+    @Override
+    public <R> ListObservable<R> mapEach(Function<E, R> mapper) {
+        return new ListMapEachObservable<>(
+                this,
+                mapper,
+                List::copyOf,
+                ArrayList::new
+        );
+    }
+
+    @Override
+    public <R> ListObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
+        return new ListFlatMapEachObservable<>(
+                this,
+                mapper,
+                List::copyOf,
+                ArrayList::new
+        );
+    }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservableImpl.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/ListObservableImpl.java
@@ -13,7 +13,6 @@ import java.util.function.Predicate;
 @ApiStatus.Internal
 /* package-private */ class ListObservableImpl<E> extends AbstractCollectionObservable<E, List<E>> implements ListObservable<E> {
 
-
     public ListObservableImpl() {
         this(new ArrayList<>());
     }
@@ -21,7 +20,6 @@ import java.util.function.Predicate;
     public ListObservableImpl(List<E> list) {
         super(list);
     }
-
 
     @Override
     public void add(int index, E element) {
@@ -75,31 +73,21 @@ import java.util.function.Predicate;
 
     @Override
     public ListObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new ListFilterObservable<>(this, filter);
+        return ListChainHelpers.filter(this, filter);
     }
 
     @Override
     public <T> ListObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return ListChainHelpers.filter(this, mapper, filter);
     }
 
     @Override
     public <R> ListObservable<R> mapEach(Function<E, R> mapper) {
-        return new ListMapEachObservable<>(
-                this,
-                mapper,
-                List::copyOf,
-                ArrayList::new
-        );
+        return ListChainHelpers.mapEach(this, mapper, List::copyOf, ArrayList::new);
     }
 
     @Override
     public <R> ListObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new ListFlatMapEachObservable<>(
-                this,
-                mapper,
-                List::copyOf,
-                ArrayList::new
-        );
+        return ListChainHelpers.flatMapEach(this, mapper, List::copyOf, ArrayList::new);
     }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/MapElementObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/MapElementObservable.java
@@ -1,0 +1,147 @@
+package net.apartium.cocoabeans.state;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * An observable implementation that maps the elements of one collection to another based on a provided mapping function.
+ * This class observes changes in the base observable and ensures the mapped collection is updated accordingly.
+ *
+ * @param <F> The type of elements in the source observable collection.
+ * @param <E> The type of elements in the mapped observable collection.
+ * @param <C> The type of the mapped collection.
+ * @see CollectionObservable
+ * @see Observable
+ * @see Observer
+ */
+@ApiStatus.AvailableSince("0.0.50")
+public class MapElementObservable<F, E, C extends Collection<E>> implements CollectionObservable<E, C>, Observer {
+
+    private final Set<Observer> observers = Collections.newSetFromMap(new WeakHashMap<>());
+
+    private final Observable<? extends Collection<F>> base;
+
+    private final Function<F, E> mapper;
+    protected final Function<Collection<E>, C> collectionMapper;
+    protected final Function<Integer, ? extends Collection<E>> constructCollection;
+
+    private final Observable<Integer> size;
+
+    private boolean baseDirty = true;
+    private C cachedCollection;
+
+    /**
+     * Constructs a new instance of the MapElementObservable class.
+     *
+     * @param base The base observable to be transformed. Changes in the base observable will be reflected in this observable.
+     * @param mapper A function used to transform elements of type F from the base observable into elements of type E.
+     * @param collectionMapper A function that takes a collection of mapped elements and transforms it into a collection of type C.
+     * @param constructCollection A function used to create a new collection of type E of a specified size.
+     */
+    public MapElementObservable(
+            Observable<? extends Collection<F>> base,
+            Function<F, E> mapper,
+            Function<Collection<E>, C> collectionMapper,
+            Function<Integer, ? extends Collection<E>> constructCollection
+    ) {
+        this.base = base;
+        this.base.observe(this);
+
+        this.mapper = mapper;
+        this.collectionMapper = collectionMapper;
+        this.constructCollection = constructCollection;
+
+        this.size = this.map(Collection::size);
+    }
+
+    @Override
+    public C get() {
+        if (!baseDirty)
+            return cachedCollection;
+
+        Collection<F> source = base.get();
+        Collection<E> mapped = constructCollection.apply(source.size());
+
+        for (F element : source)
+            mapped.add(mapper.apply(element));
+
+        cachedCollection = collectionMapper.apply(mapped);
+        baseDirty = false;
+
+        return cachedCollection;
+    }
+
+    protected void notifyObservers() {
+        for (Observer observer : observers)
+            observer.flagAsDirty(this);
+    }
+
+    @Override
+    public void flagAsDirty(Observable<?> observable) {
+        if (observable != base)
+            return;
+
+        baseDirty = true;
+        notifyObservers();
+    }
+
+    @Override
+    public void observe(Observer observer) {
+        observers.add(observer);
+    }
+
+    @Override
+    public boolean removeObserver(Observer observer) {
+        return observers.remove(observer);
+    }
+
+    @Override public boolean add(E element) { throw new UnsupportedOperationException("MapElementObservable does not support adding elements"); }
+
+    @Override public boolean remove(E element) { throw new UnsupportedOperationException("MapElementObservable does not support removing elements"); }
+
+    @Override public boolean addAll(Collection<? extends E> collection) { throw new UnsupportedOperationException("MapElementObservable does not support adding elements"); }
+
+    @Override public boolean removeAll(Collection<? extends E> collection) { throw new UnsupportedOperationException("MapElementObservable does not support removing elements"); }
+
+    @Override public boolean removeIf(Predicate<? super E> filter) { throw new UnsupportedOperationException("MapElementObservable does not support removing elements"); }
+
+    @Override public boolean retainAll(Collection<? extends E> collection) { throw new UnsupportedOperationException("MapElementObservable does not support removing elements"); }
+
+    @Override public void clear() { throw new UnsupportedOperationException("MapElementObservable does not support removing elements"); }
+
+    @Override
+    public Observable<Integer> size() {
+        return size;
+    }
+
+    @Override
+    public CollectionObservable<E, C> filter(Function<E, Observable<Boolean>> filter) {
+        return new FilterObservable<>(this, filter, collectionMapper, constructCollection);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> mapEach(Function<E, R> mapper) {
+        return new MapElementObservable<>(
+                this,
+                mapper,
+                (Function) collectionMapper,
+                (Function) constructCollection
+        );
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> CollectionObservable<R, ? extends Collection<R>> flatMapEach(Function<E, Observable<R>> mapper) {
+        return new FlatMapElementObservable<>(
+                this,
+                mapper,
+                (Function) collectionMapper,
+                (Function) constructCollection
+        );
+    }
+
+}

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Observable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Observable.java
@@ -104,6 +104,12 @@ public interface Observable<T> {
 
     /**
      * Creates a new observable set from the given set and copy function.
+     * <p>
+     * The supplied {@code copyOf} is reused for {@code mapEach}/{@code flatMapEach}-derived
+     * views with potentially different element types, so it must be <b>element-type-agnostic</b>
+     * (e.g. {@code LinkedHashSet::new}, {@code Set::copyOf}, or a {@code WeakHashSet} factory).
+     * Factories that capture element-type-specific state (such as a {@code TreeSet} with a
+     * {@code Comparator<E>}) will throw {@link ClassCastException} when applied to a mapped view.
      *
      * @param set the original set to be wrapped as an observable set
      * @param copyOf a function that creates a new set instance as a copy of the provided collection
@@ -116,6 +122,12 @@ public interface Observable<T> {
 
     /**
      * Creates an observable set based on the provided set, copy function, and initialization set function.
+     * <p>
+     * Both {@code copyOf} and {@code createInitSet} are reused for {@code mapEach}/{@code flatMapEach}-derived
+     * views with potentially different element types, so they must be <b>element-type-agnostic</b>
+     * (e.g. {@code LinkedHashSet::new}, {@code Set::copyOf}, or a {@code WeakHashSet} factory).
+     * Factories that capture element-type-specific state (such as a {@code TreeSet} with a
+     * {@code Comparator<E>}) will throw {@link ClassCastException} when applied to a mapped view.
      *
      * @param <E> the type of elements in the set
      * @param set the initial set of elements

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetChainHelpers.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetChainHelpers.java
@@ -1,0 +1,54 @@
+package net.apartium.cocoabeans.state;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+@ApiStatus.Internal
+/* package-private */ final class SetChainHelpers {
+
+    private SetChainHelpers() {}
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static <F, R> SetObservable<R> mapEach(
+            Observable<? extends Collection<F>> base,
+            Function<F, R> mapper,
+            Function<?, ?> collectionMapper,
+            Function<?, ?> constructCollection
+    ) {
+        return new SetMapEachObservable<>(base, mapper, (Function) collectionMapper, (Function) constructCollection);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static <F, R> SetObservable<R> flatMapEach(
+            Observable<? extends Collection<F>> base,
+            Function<F, Observable<R>> mapper,
+            Function<?, ?> collectionMapper,
+            Function<?, ?> constructCollection
+    ) {
+        return new SetFlatMapEachObservable<>(base, mapper, (Function) collectionMapper, (Function) constructCollection);
+    }
+
+    static <E> SetObservable<E> filter(
+            Observable<Set<E>> base,
+            Function<E, Observable<Boolean>> filter,
+            Function<Collection<E>, Set<E>> copyOf,
+            Function<Integer, ? extends Collection<E>> createInitSet
+    ) {
+        return new SetFilterObservable<>(base, filter, copyOf, createInitSet);
+    }
+
+    static <E, T> SetObservable<E> filter(
+            Observable<Set<E>> base,
+            Function<E, Observable<T>> mapper,
+            Predicate<T> filter,
+            Function<Collection<E>, Set<E>> copyOf,
+            Function<Integer, ? extends Collection<E>> createInitSet
+    ) {
+        return filter(base, element -> mapper.apply(element).map(filter::test), copyOf, createInitSet);
+    }
+
+}

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetFilterObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetFilterObservable.java
@@ -1,9 +1,13 @@
 package net.apartium.cocoabeans.state;
 
-import java.util.*;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Collection;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+@ApiStatus.Internal
 /* package-private */ class SetFilterObservable<E> extends FilterObservable<E, Set<E>> implements SetObservable<E> {
 
     public SetFilterObservable(Observable<Set<E>> base, Function<E, Observable<Boolean>> filter, Function<Collection<E>, Set<E>> copyOf, Function<Integer, ? extends Collection<E>> createInitSet) {
@@ -12,33 +16,21 @@ import java.util.function.Predicate;
 
     @Override
     public SetObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new SetFilterObservable<>(this, filter, this.collectionMapper, this.constructCollection);
+        return SetChainHelpers.filter(this, filter, collectionMapper, constructCollection);
     }
 
     @Override
     public <T> SetObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return SetChainHelpers.filter(this, mapper, filter, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> SetObservable<R> mapEach(Function<E, R> mapper) {
-        return new SetMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return SetChainHelpers.mapEach(this, mapper, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> SetObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new SetFlatMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return SetChainHelpers.flatMapEach(this, mapper, collectionMapper, constructCollection);
     }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetFlatMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetFlatMapEachObservable.java
@@ -1,13 +1,14 @@
 package net.apartium.cocoabeans.state;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/* package-private */ class SetFilterObservable<E> extends FilterObservable<E, Set<E>> implements SetObservable<E> {
+/* package-private */ class SetFlatMapEachObservable<F, E> extends FlatMapElementObservable<F, E, Set<E>> implements SetObservable<E> {
 
-    public SetFilterObservable(Observable<Set<E>> base, Function<E, Observable<Boolean>> filter, Function<Collection<E>, Set<E>> copyOf, Function<Integer, ? extends Collection<E>> createInitSet) {
-        super(base, filter, copyOf, createInitSet);
+    public SetFlatMapEachObservable(Observable<? extends Collection<F>> base, Function<F, Observable<E>> mapper, Function<Collection<E>, Set<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
+        super(base, mapper, collectionMapper, constructCollection);
     }
 
     @Override

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetFlatMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetFlatMapEachObservable.java
@@ -1,10 +1,13 @@
 package net.apartium.cocoabeans.state;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+@ApiStatus.Internal
 /* package-private */ class SetFlatMapEachObservable<F, E> extends FlatMapElementObservable<F, E, Set<E>> implements SetObservable<E> {
 
     public SetFlatMapEachObservable(Observable<? extends Collection<F>> base, Function<F, Observable<E>> mapper, Function<Collection<E>, Set<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
@@ -13,33 +16,21 @@ import java.util.function.Predicate;
 
     @Override
     public SetObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new SetFilterObservable<>(this, filter, this.collectionMapper, this.constructCollection);
+        return SetChainHelpers.filter(this, filter, collectionMapper, constructCollection);
     }
 
     @Override
     public <T> SetObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return SetChainHelpers.filter(this, mapper, filter, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> SetObservable<R> mapEach(Function<E, R> mapper) {
-        return new SetMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return SetChainHelpers.mapEach(this, mapper, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> SetObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new SetFlatMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return SetChainHelpers.flatMapEach(this, mapper, collectionMapper, constructCollection);
     }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetMapEachObservable.java
@@ -1,13 +1,14 @@
 package net.apartium.cocoabeans.state;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/* package-private */ class SetFilterObservable<E> extends FilterObservable<E, Set<E>> implements SetObservable<E> {
+/* package-private */ class SetMapEachObservable<F, E> extends MapElementObservable<F, E, Set<E>> implements SetObservable<E> {
 
-    public SetFilterObservable(Observable<Set<E>> base, Function<E, Observable<Boolean>> filter, Function<Collection<E>, Set<E>> copyOf, Function<Integer, ? extends Collection<E>> createInitSet) {
-        super(base, filter, copyOf, createInitSet);
+    public SetMapEachObservable(Observable<? extends Collection<F>> base, Function<F, E> mapper, Function<Collection<E>, Set<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
+        super(base, mapper, collectionMapper, constructCollection);
     }
 
     @Override

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetMapEachObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetMapEachObservable.java
@@ -1,10 +1,13 @@
 package net.apartium.cocoabeans.state;
 
+import org.jetbrains.annotations.ApiStatus;
+
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+@ApiStatus.Internal
 /* package-private */ class SetMapEachObservable<F, E> extends MapElementObservable<F, E, Set<E>> implements SetObservable<E> {
 
     public SetMapEachObservable(Observable<? extends Collection<F>> base, Function<F, E> mapper, Function<Collection<E>, Set<E>> collectionMapper, Function<Integer, ? extends Collection<E>> constructCollection) {
@@ -13,33 +16,21 @@ import java.util.function.Predicate;
 
     @Override
     public SetObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new SetFilterObservable<>(this, filter, this.collectionMapper, this.constructCollection);
+        return SetChainHelpers.filter(this, filter, collectionMapper, constructCollection);
     }
 
     @Override
     public <T> SetObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return SetChainHelpers.filter(this, mapper, filter, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> SetObservable<R> mapEach(Function<E, R> mapper) {
-        return new SetMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return SetChainHelpers.mapEach(this, mapper, collectionMapper, constructCollection);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> SetObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new SetFlatMapEachObservable<>(
-                this,
-                mapper,
-                (Function) collectionMapper,
-                (Function) constructCollection
-        );
+        return SetChainHelpers.flatMapEach(this, mapper, collectionMapper, constructCollection);
     }
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservable.java
@@ -2,6 +2,7 @@ package net.apartium.cocoabeans.state;
 
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -21,4 +22,11 @@ public interface SetObservable<E> extends CollectionObservable<E, Set<E>> {
     @Override
     <T> SetObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter);
 
+    @ApiStatus.AvailableSince("0.0.50")
+    @Override
+    <R> SetObservable<R> mapEach(Function<E, R> mapper);
+
+    @ApiStatus.AvailableSince("0.0.50")
+    @Override
+    <R> SetObservable<R> flatMapEach(Function<E, Observable<R>> mapper);
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservable.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservable.java
@@ -2,7 +2,6 @@ package net.apartium.cocoabeans.state;
 
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.Collection;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservableImpl.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservableImpl.java
@@ -59,4 +59,28 @@ import java.util.function.Predicate;
     public <T> SetObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
         return this.filter(element -> mapper.apply(element).map(filter::test));
     }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> SetMapEachObservable<E, R> mapEach(Function<E, R> mapper) {
+        return new SetMapEachObservable<>(
+                this,
+                mapper,
+                (Function) copyOf,
+                (Function) createInitSet
+        );
+    }
+
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <R> SetObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
+        return new SetFlatMapEachObservable<>(
+                this,
+                mapper,
+                (Function) copyOf,
+                (Function) createInitSet
+        );
+    }
+
 }

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservableImpl.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/SetObservableImpl.java
@@ -52,35 +52,22 @@ import java.util.function.Predicate;
 
     @Override
     public SetObservable<E> filter(Function<E, Observable<Boolean>> filter) {
-        return new SetFilterObservable<>(this, filter, copyOf, createInitSet);
+        return SetChainHelpers.filter(this, filter, copyOf, createInitSet);
     }
 
     @Override
     public <T> SetObservable<E> filter(Function<E, Observable<T>> mapper, Predicate<T> filter) {
-        return this.filter(element -> mapper.apply(element).map(filter::test));
+        return SetChainHelpers.filter(this, mapper, filter, copyOf, createInitSet);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public <R> SetMapEachObservable<E, R> mapEach(Function<E, R> mapper) {
-        return new SetMapEachObservable<>(
-                this,
-                mapper,
-                (Function) copyOf,
-                (Function) createInitSet
-        );
+    public <R> SetObservable<R> mapEach(Function<E, R> mapper) {
+        return SetChainHelpers.mapEach(this, mapper, copyOf, createInitSet);
     }
 
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <R> SetObservable<R> flatMapEach(Function<E, Observable<R>> mapper) {
-        return new SetFlatMapEachObservable<>(
-                this,
-                mapper,
-                (Function) copyOf,
-                (Function) createInitSet
-        );
+        return SetChainHelpers.flatMapEach(this, mapper, copyOf, createInitSet);
     }
 
 }

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/CodeSnippets.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/CodeSnippets.java
@@ -364,8 +364,7 @@ class CodeSnippets {
     void filteredCollection() {
         SetObservable<GamePlayer> players = Observable.set();
 
-        CollectionObservable<GamePlayer, Set<GamePlayer>> alivePlayers =
-                players.filter(GamePlayer::getAlive);
+        SetObservable<GamePlayer> alivePlayers = players.filter(GamePlayer::getAlive);
 
         GamePlayer a = new GamePlayer(UUID.randomUUID());
         GamePlayer b = new GamePlayer(UUID.randomUUID());
@@ -449,6 +448,57 @@ class CodeSnippets {
         rank.set(rankA);
         prefixA.set("[A-]");
         assertEquals("[A-]", prefix.get());
+    }
+
+    @Test
+    void mapEachSample() {
+        ListObservable<String> names = Observable.list();
+
+        // mapEach derives a ListObservable<Integer> of per-element lengths
+        ListObservable<Integer> lengths = names.mapEach(String::length);
+
+        names.add("kfir");
+        names.add("apartium");
+        assertEquals(List.of(4, 8), lengths.get());
+
+        names.add("voigon");
+        assertEquals(List.of(4, 8, 6), lengths.get());
+
+        names.remove("kfir");
+        assertEquals(List.of(8, 6), lengths.get());
+    }
+
+    public record DisplayPlayer(String id, MutableObservable<String> displayName) {}
+
+    @Test
+    void flatMapEachSample() {
+        DisplayPlayer kfir = new DisplayPlayer("kfir", Observable.mutable("kfir"));
+        DisplayPlayer lior = new DisplayPlayer("lior", Observable.mutable("lior"));
+
+        ListObservable<DisplayPlayer> players = Observable.list();
+        players.add(kfir);
+        players.add(lior);
+
+        // flatMapEach exposes the current value of each element's inner observable
+        ListObservable<String> displayNames = players.flatMapEach(DisplayPlayer::displayName);
+
+        assertEquals(List.of("kfir", "lior"), displayNames.get());
+
+        // updates when any tracked element's inner observable changes
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "lior"), displayNames.get());
+
+        // updates when the source collection changes
+        DisplayPlayer voigon = new DisplayPlayer("voigon", Observable.mutable("voigon"));
+        players.add(voigon);
+        assertEquals(List.of("Kfir Notro", "lior", "voigon"), displayNames.get());
+
+        players.remove(kfir);
+        assertEquals(List.of("lior", "voigon"), displayNames.get());
+
+        // mutating an element that is no longer tracked does NOT propagate
+        kfir.displayName().set("ghost");
+        assertEquals(List.of("lior", "voigon"), displayNames.get());
     }
 
 }

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/CollectionObservableManipulationTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/CollectionObservableManipulationTest.java
@@ -1,0 +1,68 @@
+package net.apartium.cocoabeans.state;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CollectionObservableManipulationTest {
+
+    @Test
+    void mapEachFilterFlatMapEachShouldChainCorrectly() {
+        MutableObservable<String> kfirDisplayName = Observable.mutable("Kfir");
+        MutableObservable<String> apartiumDisplayName = Observable.mutable("Apartium");
+        MutableObservable<String> voigonDisplayName = Observable.mutable("voigon");
+
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), "kfir", kfirDisplayName, Observable.immutable(true));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), "apartium", apartiumDisplayName, Observable.immutable(true));
+        GamePlayer voigon = new GamePlayer(UUID.randomUUID(), "voigon", voigonDisplayName, Observable.immutable(false));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                kfir,
+                apartium,
+                voigon
+        )));
+
+        ListObservable<String> displayNames = players
+                .mapEach(player -> new PlayerView(
+                        player.name(),
+                        player.displayName(),
+                        player.alive()
+                ))
+                .filter(PlayerView::alive)
+                .flatMapEach(PlayerView::displayName);
+
+        assertEquals(List.of("Kfir", "Apartium"), displayNames.get());
+
+        kfirDisplayName.set("Kfir2");
+
+        assertEquals(List.of("Kfir2", "Apartium"), displayNames.get());
+
+        voigonDisplayName.set("voigon2");
+
+        assertEquals(List.of("Kfir2", "Apartium"), displayNames.get());
+
+        apartiumDisplayName.set("Apartium2");
+
+        assertEquals(List.of("Kfir2", "Apartium2"), displayNames.get());
+    }
+
+    private record GamePlayer(
+            UUID uuid,
+            String name,
+            MutableObservable<String> displayName,
+            Observable<Boolean> alive
+    ) {}
+
+    private record PlayerView(
+            String name,
+            Observable<String> displayName,
+            Observable<Boolean> alive
+    ) {
+
+    }
+    
+}

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/FlatMapElementObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/FlatMapElementObservableTest.java
@@ -2,15 +2,91 @@ package net.apartium.cocoabeans.state;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.lang.reflect.Field;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class FlatMapElementObservableTest {
+
+    @Test
+    void flatMapEachShouldContainsDupe() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+
+        apartium.name().set("Kfir");
+
+        assertEquals(List.of("Kfir", "Kfir"), names.get());
+
+        kfir.name().set("Apartium");
+
+        assertEquals(List.of("Apartium", "Kfir"), names.get());
+    }
+
+    @Test
+    void flatMapEacMultiDupe() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium, kfir, kfir, apartium)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium", "Kfir", "Kfir", "Apartium"), names.get());
+
+        players.remove(4);
+
+        assertEquals(List.of("Kfir", "Apartium", "Kfir", "Kfir"), names.get());
+
+        players.remove(3);
+        kfir.name().set("Kfir2");
+
+        assertEquals(List.of("Kfir2", "Apartium", "Kfir2"), names.get());
+
+        try {
+            Field observers = MutableObservableImpl.class.getDeclaredField("observers");
+            observers.setAccessible(true);
+
+            Set<Observer> kfirObservers = (Set<Observer>) observers.get(kfir.name);
+
+            assertEquals(1, kfirObservers.size());
+
+            players.removeIf(player -> kfir == player);
+
+            assertEquals(List.of("Apartium"), names.get());
+            assertEquals(0, kfirObservers.size());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            fail(e);
+        }
+
+    }
+
+    @Test
+    void flatMapEachShouldRemoveDupeOnSet() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        SetObservable<GamePlayer> players = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(Set.of("Kfir", "Apartium"), names.get());
+
+        apartium.name().set("Kfir");
+
+        assertEquals(Set.of("Kfir"), names.get());
+
+        kfir.name().set("Apartium");
+
+        assertEquals(Set.of("Apartium", "Kfir"), names.get());
+    }
 
     @Test
     void flatMapEachShouldMapExistingElements() {

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/FlatMapElementObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/FlatMapElementObservableTest.java
@@ -1,0 +1,262 @@
+package net.apartium.cocoabeans.state;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FlatMapElementObservableTest {
+
+    @Test
+    void flatMapEachShouldMapExistingElements() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachShouldUpdateWhenInnerObservableChanges() {
+        MutableObservable<String> name = Observable.mutable("Kfir");
+
+        GamePlayer player = new GamePlayer(UUID.randomUUID(), name);
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(player)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir"), names.get());
+
+        name.set("Apartium");
+
+        assertEquals(List.of("Apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachShouldUpdateWhenElementIsAdded() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir"), names.get());
+
+        players.add(apartium);
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachShouldUpdateWhenElementIsRemoved() {
+        MutableObservable<String> removedName = Observable.mutable("Kfir");
+
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), removedName);
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+
+        players.remove(kfir);
+
+        assertEquals(List.of("Apartium"), names.get());
+
+        removedName.set("Kfir2");
+
+        assertEquals(List.of("Apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachShouldUpdateWhenCollectionIsCleared() {
+        MutableObservable<String> name = Observable.mutable("Kfir");
+
+        GamePlayer player = new GamePlayer(UUID.randomUUID(), name);
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(player)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir"), names.get());
+
+        players.clear();
+
+        assertEquals(List.of(), names.get());
+
+        name.set("Kfir2");
+
+        assertEquals(List.of(), names.get());
+    }
+
+    @Test
+    void flatMapEachShouldCacheUntilBaseOrInnerChanges() {
+        MutableObservable<String> name = Observable.mutable("Kfir");
+
+        GamePlayer player = new GamePlayer(UUID.randomUUID(), name);
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(player)));
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+
+        ListObservable<String> names = players.flatMapEach(gamePlayer -> {
+            mapperCalls.incrementAndGet();
+            return gamePlayer.name();
+        });
+
+        assertEquals(List.of("Kfir"), names.get());
+        assertEquals(List.of("Kfir"), names.get());
+        assertEquals(List.of("Kfir"), names.get());
+
+        assertEquals(1, mapperCalls.get());
+
+        name.set("Kfir2");
+
+        assertEquals(List.of("Kfir2"), names.get());
+
+        assertEquals(1, mapperCalls.get());
+
+        players.add(new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium")));
+
+        assertEquals(List.of("Kfir2", "Apartium"), names.get());
+
+        assertEquals(2, mapperCalls.get());
+
+        assertEquals(List.of("Kfir2", "Apartium"), names.get());
+        assertEquals(List.of("Kfir2", "Apartium"), names.get());
+        assertEquals(List.of("Kfir2", "Apartium"), names.get());
+
+        assertEquals(2, mapperCalls.get());
+    }
+
+    @Test
+    void flatMapEachShouldExposeMappedSize() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(1, names.size().get());
+
+        players.add(apartium);
+
+        assertEquals(2, names.size().get());
+
+        players.clear();
+
+        assertEquals(0, names.size().get());
+    }
+
+    @Test
+    void flatMapEachShouldNotifyObserversWhenInnerObservableChanges() {
+        MutableObservable<String> name = Observable.mutable("Kfir");
+
+        GamePlayer player = new GamePlayer(UUID.randomUUID(), name);
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(player)));
+
+        ListObservable<String> names = players.flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir"), names.get());
+
+        TestObserver observer = new TestObserver();
+        names.observe(observer);
+
+        name.set("Kfir2");
+
+        assertTrue(observer.dirty);
+        assertSame(names, observer.observable);
+
+        assertEquals(List.of("Kfir2"), names.get());
+    }
+
+    @Test
+    void flatMapEachShouldWorkAfterFilter() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"), true);
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"), false);
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> aliveNames = players
+                .filter(player -> Observable.immutable(player.alive()))
+                .flatMapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir"), aliveNames.get());
+
+        kfir.name().set("Kfir2");
+
+        assertEquals(List.of("Kfir2"), aliveNames.get());
+    }
+
+    @Test
+    void flatMapEachShouldWorkBeforeFilter() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), Observable.mutable("Kfir"));
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), Observable.mutable("Apartium"));
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> namesStartingWithA = players
+                .flatMapEach(GamePlayer::name)
+                .filter(name -> Observable.immutable(name.startsWith("A")));
+
+        assertEquals(List.of("Apartium"), namesStartingWithA.get());
+
+        kfir.name().set("AlsoKfir");
+
+        assertEquals(List.of("AlsoKfir", "Apartium"), namesStartingWithA.get());
+    }
+
+    @Test
+    void flatMapEachShouldSupportChaining() {
+        MutableObservable<String> name = Observable.mutable("Kfir");
+
+        GamePlayer player = new GamePlayer(UUID.randomUUID(), name);
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(player)));
+
+        ListObservable<Integer> nameLengths = players
+                .flatMapEach(GamePlayer::name)
+                .mapEach(String::length);
+
+        assertEquals(List.of(4), nameLengths.get());
+
+        name.set("Apartium");
+
+        assertEquals(List.of(8), nameLengths.get());
+    }
+
+    private record GamePlayer(UUID uuid, MutableObservable<String> name, boolean alive) {
+
+        private GamePlayer(UUID uuid, MutableObservable<String> name) {
+            this(uuid, name, true);
+        }
+
+    }
+
+    private static class TestObserver implements Observer {
+
+        private boolean dirty;
+        private Observable<?> observable;
+
+        @Override
+        public void flagAsDirty(Observable<?> observable) {
+            this.dirty = true;
+            this.observable = observable;
+        }
+
+    }
+
+}

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
@@ -241,16 +241,22 @@ class ListObservableTest {
         // inherited from MapElementObservable
         assertThrows(UnsupportedOperationException.class, () -> mapped.add(1));
         assertThrows(UnsupportedOperationException.class, () -> mapped.remove((Integer) 1));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+
+        List<Integer> collection = List.of();
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(collection));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(collection));
         assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(collection));
         assertThrows(UnsupportedOperationException.class, mapped::clear);
 
         // list-specific overrides
         assertThrows(UnsupportedOperationException.class, () -> mapped.add(0, 1));
         assertThrows(UnsupportedOperationException.class, () -> mapped.remove(0));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.sort(Comparator.naturalOrder()));
+
+        Comparator<Integer> comparator = Comparator.naturalOrder();
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.sort(comparator));
     }
 
     @Test
@@ -534,16 +540,22 @@ class ListObservableTest {
         // inherited from FlatMapElementObservable
         assertThrows(UnsupportedOperationException.class, () -> mapped.add("x"));
         assertThrows(UnsupportedOperationException.class, () -> mapped.remove("x"));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+
+        List<String> collection = List.of();
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(collection));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(collection));
         assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(collection));
         assertThrows(UnsupportedOperationException.class, mapped::clear);
 
         // list-specific overrides
         assertThrows(UnsupportedOperationException.class, () -> mapped.add(0, "x"));
         assertThrows(UnsupportedOperationException.class, () -> mapped.remove(0));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.sort(Comparator.naturalOrder()));
+
+        Comparator<String> comparator = Comparator.naturalOrder();
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.sort(comparator));
     }
 
     @Test
@@ -799,16 +811,22 @@ class ListObservableTest {
         // inherited from FilterObservable
         assertThrows(UnsupportedOperationException.class, () -> filtered.add(1));
         assertThrows(UnsupportedOperationException.class, () -> filtered.remove((Integer) 1));
-        assertThrows(UnsupportedOperationException.class, () -> filtered.addAll(List.of()));
-        assertThrows(UnsupportedOperationException.class, () -> filtered.removeAll(List.of()));
+
+        List<Integer> collection = List.of();
+
+        assertThrows(UnsupportedOperationException.class, () -> filtered.addAll(collection));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.removeAll(collection));
         assertThrows(UnsupportedOperationException.class, () -> filtered.removeIf(n -> true));
-        assertThrows(UnsupportedOperationException.class, () -> filtered.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.retainAll(collection));
         assertThrows(UnsupportedOperationException.class, filtered::clear);
 
         // list-specific overrides on ListFilterObservable
         assertThrows(UnsupportedOperationException.class, () -> filtered.add(0, 1));
         assertThrows(UnsupportedOperationException.class, () -> filtered.remove(0));
-        assertThrows(UnsupportedOperationException.class, () -> filtered.sort(Comparator.naturalOrder()));
+
+        Comparator<Integer> comparator = Comparator.naturalOrder();
+
+        assertThrows(UnsupportedOperationException.class, () -> filtered.sort(comparator));
     }
 
     @Test

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -332,6 +334,36 @@ class ListObservableTest {
 
         sharedName.set("Kfir Notro");
         assertEquals(List.of("Kfir Notro", "Kfir Notro"), names.get());
+    }
+
+    @Test
+    void flatMapEachEqualButDistinctElementsEachReceiveOwnMapperInvocation() {
+        // Two value-equal source elements that are distinct references must each
+        // get their own mapper invocation. With identity-keyed bookkeeping, the
+        // mapper can return a different observable per occurrence and both are honored.
+        record Token(String id) {}
+
+        Token first = new Token("kfir");
+        Token second = new Token("kfir");
+
+        assertEquals(first, second, "records compare equal by component values");
+        assertNotSame(first, second);
+
+        Map<Token, MutableObservable<String>> backing = new IdentityHashMap<>();
+        backing.put(first, Observable.mutable("first"));
+        backing.put(second, Observable.mutable("second"));
+
+        ListObservable<Token> list = Observable.list(new ArrayList<>(List.of(first, second)));
+        ListObservable<String> names = (ListObservable<String>) list.flatMapEach(backing::get);
+
+        assertEquals(List.of("first", "second"), names.get());
+
+        backing.get(first).set("first-updated");
+        assertEquals(List.of("first-updated", "second"), names.get(),
+                "updating one element's inner observable must not affect the other");
+
+        backing.get(second).set("second-updated");
+        assertEquals(List.of("first-updated", "second-updated"), names.get());
     }
 
     @Test
@@ -797,11 +829,8 @@ class ListObservableTest {
 
         assertEquals(List.of(apartium), startsWithVowel.get());
 
-        // when an element flips into the filter via incremental update, FilterObservable's
-        // updateFlagged path appends it to the cached list rather than re-running from
-        // base order — so the order here reflects the incremental-update behavior.
         kfir.displayName().set("orion");
-        assertEquals(List.of(apartium, kfir), startsWithVowel.get());
+        assertEquals(List.of(kfir, apartium), startsWithVowel.get());
     }
 
     @Test
@@ -860,11 +889,8 @@ class ListObservableTest {
         kfir.active().set(false);
         assertEquals(List.of(apartium), active.get());
 
-        // re-adding kfir via the incremental updateFlagged path appends to the end of the
-        // cached list rather than restoring source order — a documented quirk of the
-        // current implementation that we lock down here.
         kfir.active().set(true);
-        assertEquals(List.of(apartium, kfir), active.get());
+        assertEquals(List.of(kfir, apartium), active.get());
     }
 
     @Test
@@ -892,6 +918,781 @@ class ListObservableTest {
 
         list.sort(Comparator.naturalOrder());
         assertEquals(List.of(2, 4), evens.get());
+    }
+
+    @Test
+    void filterPreservesBaseOrderWithSharedFilterObservable() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        Member voigon = new Member("voigon");
+
+        Observable<Boolean> alwaysTrue = Observable.immutable(true);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, voigon)));
+        ListObservable<Member> filtered = list.filter(member -> alwaysTrue);
+
+        assertEquals(List.of(kfir, apartium, voigon), filtered.get());
+    }
+
+    @Test
+    void filterPreservesDuplicateOccurrencesInList() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir, kfir), active.get());
+
+        kfir.active().set(false);
+        assertEquals(List.of(), active.get());
+
+        kfir.active().set(true);
+        assertEquals(List.of(kfir, kfir), active.get());
+    }
+
+    @Test
+    void filterPreservesInterleavedDuplicatesUnderSharedObservable() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, kfir)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir, apartium, kfir), active.get());
+
+        apartium.active().set(false);
+        assertEquals(List.of(kfir, kfir), active.get());
+
+        apartium.active().set(true);
+        assertEquals(List.of(kfir, apartium, kfir), active.get());
+
+        kfir.active().set(false);
+        assertEquals(List.of(apartium), active.get());
+    }
+
+    // ---------------------------------------------------------------------
+    // duplicate-focused tests (mapEach, flatMapEach, filter)
+    // ---------------------------------------------------------------------
+
+    @Test
+    void mapEachAllSameElementProducesAllSameMapped() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of(
+                "kfir", "kfir", "kfir", "kfir"
+        )));
+
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+
+        assertEquals(List.of(4, 4, 4, 4), lengths.get());
+        assertEquals(4, lengths.size().get());
+    }
+
+    @Test
+    void mapEachAddingMoreDuplicatesGrows() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "kfir")));
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+
+        assertEquals(List.of(4, 4), lengths.get());
+
+        list.add("kfir");
+        list.add("kfir");
+        assertEquals(List.of(4, 4, 4, 4), lengths.get());
+    }
+
+    @Test
+    void mapEachRemovingOnlyOneOccurrenceOfDuplicateShrinksByOne() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of(
+                "kfir", "apartium", "kfir", "voigon", "kfir"
+        )));
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+
+        assertEquals(List.of(4, 8, 4, 6, 4), lengths.get());
+
+        list.remove("kfir");
+        assertEquals(List.of(8, 4, 6, 4), lengths.get(), "List.remove(Object) drops only the first occurrence");
+    }
+
+    @Test
+    void mapEachClearOfDuplicatesYieldsEmpty() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of(
+                "kfir", "kfir", "kfir"
+        )));
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+
+        assertEquals(List.of(4, 4, 4), lengths.get());
+
+        list.clear();
+        assertEquals(List.of(), lengths.get());
+        assertEquals(0, lengths.size().get());
+    }
+
+    @Test
+    void mapEachInvokesMapperPerOccurrenceForDuplicates() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "kfir", "kfir")));
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Integer> lengths = list.mapEach(name -> {
+            mapperCalls.incrementAndGet();
+            return name.length();
+        });
+
+        assertEquals(List.of(4, 4, 4), lengths.get());
+        assertEquals(3, mapperCalls.get(), "mapEach invokes the mapper once per source occurrence");
+    }
+
+    @Test
+    void flatMapEachAllSameRefAllSameValue() {
+        Member kfir = new Member("kfir");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+
+        assertEquals(List.of("kfir", "kfir", "kfir"), names.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "Kfir Notro", "Kfir Notro"), names.get(),
+                "a single inner change reflects in every duplicate occurrence");
+    }
+
+    @Test
+    void flatMapEachInnerChangePropagatesToEveryOccurrenceWithMixedNeighbors() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        Member voigon = new Member("voigon");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(
+                kfir, apartium, kfir, voigon, kfir
+        )));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+
+        assertEquals(List.of("kfir", "apartium", "kfir", "voigon", "kfir"), names.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "apartium", "Kfir Notro", "voigon", "Kfir Notro"), names.get());
+    }
+
+    @Test
+    void flatMapEachAddingMoreDuplicatesAfterMaterializationKeepsSubscriptionDeduped() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<String> names = list.flatMapEach(member -> {
+            mapperCalls.incrementAndGet();
+            return member.displayName();
+        });
+
+        assertEquals(List.of("kfir"), names.get());
+        assertEquals(1, mapperCalls.get());
+
+        list.add(kfir);
+        list.add(kfir);
+        assertEquals(List.of("kfir", "kfir", "kfir"), names.get());
+        assertEquals(1, mapperCalls.get(), "flatMapEach mapper is invoked once per unique element, not per occurrence");
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "Kfir Notro", "Kfir Notro"), names.get());
+    }
+
+    @Test
+    void flatMapEachRemovingOneOfManyOccurrencesKeepsRest() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(
+                kfir, kfir, apartium, kfir
+        )));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+
+        assertEquals(List.of("kfir", "kfir", "apartium", "kfir"), names.get());
+
+        list.remove(kfir);
+        assertEquals(List.of("kfir", "apartium", "kfir"), names.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "apartium", "Kfir Notro"), names.get(),
+                "remaining occurrences must still be tracked after a single occurrence is removed");
+    }
+
+    @Test
+    void flatMapEachRemovingAllOccurrencesAndReAddingResubscribes() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+
+        assertEquals(List.of("kfir", "kfir", "kfir"), names.get());
+
+        list.clear();
+        assertEquals(List.of(), names.get());
+
+        // change while not present — must not propagate (no observer)
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of(), names.get());
+
+        list.add(kfir);
+        list.add(kfir);
+        assertEquals(List.of("Kfir Notro", "Kfir Notro"), names.get(),
+                "re-adding picks up the current inner value");
+
+        kfir.displayName().set("Kfir Apartium");
+        assertEquals(List.of("Kfir Apartium", "Kfir Apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachThenMapEachOverDuplicates() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, kfir)));
+
+        ListObservable<Integer> nameLengths = (ListObservable<Integer>) list
+                .flatMapEach(Member::displayName)
+                .mapEach(String::length);
+
+        assertEquals(List.of(4, 8, 4), nameLengths.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of(10, 8, 10), nameLengths.get());
+    }
+
+    @Test
+    void filterAllDuplicatesPredicateFlipTogglesAllAtOnce() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir, kfir)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir, kfir, kfir, kfir), active.get());
+        assertEquals(4, active.size().get());
+
+        kfir.active().set(false);
+        assertEquals(List.of(), active.get());
+        assertEquals(0, active.size().get());
+
+        kfir.active().set(true);
+        assertEquals(List.of(kfir, kfir, kfir, kfir), active.get());
+    }
+
+    @Test
+    void filterRemovingOneOccurrenceOfDuplicateShrinksByOne() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, kfir, kfir)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir, apartium, kfir, kfir), active.get());
+
+        list.remove(kfir);
+        assertEquals(List.of(apartium, kfir, kfir), active.get());
+
+        kfir.active().set(false);
+        assertEquals(List.of(apartium), active.get(),
+                "predicate flip after removing one occurrence still excludes every remaining occurrence");
+    }
+
+    @Test
+    void filterThenMapEachOverDuplicates() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        apartium.active().set(false);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(
+                kfir, apartium, kfir, apartium, kfir
+        )));
+
+        ListObservable<String> ids = (ListObservable<String>) list
+                .filter(Member::active)
+                .mapEach(Member::id);
+
+        assertEquals(List.of("kfir", "kfir", "kfir"), ids.get());
+
+        apartium.active().set(true);
+        assertEquals(List.of("kfir", "apartium", "kfir", "apartium", "kfir"), ids.get());
+    }
+
+    @Test
+    void filterThenFlatMapEachOverDuplicates() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(
+                kfir, apartium, kfir, kfir
+        )));
+
+        ListObservable<String> activeNames = (ListObservable<String>) list
+                .filter(Member::active)
+                .flatMapEach(Member::displayName);
+
+        assertEquals(List.of("kfir", "apartium", "kfir", "kfir"), activeNames.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "apartium", "Kfir Notro", "Kfir Notro"), activeNames.get());
+
+        kfir.active().set(false);
+        assertEquals(List.of("apartium"), activeNames.get());
+
+        kfir.active().set(true);
+        assertEquals(List.of("Kfir Notro", "apartium", "Kfir Notro", "Kfir Notro"), activeNames.get());
+    }
+
+    @Test
+    void mapEachThenFilterOverDuplicates() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of(
+                "kfir", "apartium", "kfir", "voigon", "kfir"
+        )));
+
+        // mapEach then filter (filter elements with length == 4)
+        ListObservable<Integer> shortLengths = (ListObservable<Integer>) list
+                .mapEach(String::length)
+                .filter(n -> Observable.immutable(n == 4));
+
+        assertEquals(List.of(4, 4, 4), shortLengths.get());
+    }
+
+    @Test
+    void filterChainedFilterOverDuplicatesPreservesEachOccurrence() {
+        ListObservable<Integer> list = Observable.list(new ArrayList<>(List.of(
+                1, 2, 2, 3, 4, 4, 4, 5, 6, 6
+        )));
+
+        ListObservable<Integer> evenAndLarge = list
+                .filter(n -> Observable.immutable(n % 2 == 0))
+                .filter(n -> Observable.immutable(n >= 4));
+
+        assertEquals(List.of(4, 4, 4, 6, 6), evenAndLarge.get());
+    }
+
+    @Test
+    void filterSharedFilterObservableTogglesAllOccurrences() {
+        MutableObservable<Boolean> shared = Observable.mutable(true);
+
+        Member kfir = new Member("kfir", Observable.mutable("kfir"), shared);
+        Member lior = new Member("lior", Observable.mutable("lior"), shared);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(
+                kfir, lior, kfir, lior, kfir
+        )));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir, lior, kfir, lior, kfir), active.get());
+
+        shared.set(false);
+        assertEquals(List.of(), active.get(),
+                "single shared predicate flip excludes every occurrence");
+
+        shared.set(true);
+        assertEquals(List.of(kfir, lior, kfir, lior, kfir), active.get());
+    }
+
+    @Test
+    void filterDeduplicatesSubscriptionForRepeatedElement() {
+        Member kfir = new Member("kfir");
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir, kfir)));
+
+        ListObservable<Member> active = list.filter(member -> {
+            mapperCalls.incrementAndGet();
+            return member.active();
+        });
+
+        assertEquals(List.of(kfir, kfir, kfir, kfir), active.get());
+        assertEquals(1, mapperCalls.get(),
+                "filter mapper is invoked once per unique element, not per occurrence");
+    }
+
+    // ---------------------------------------------------------------------
+    // counter-driven dup tests — verify no unnecessary work
+    // ---------------------------------------------------------------------
+
+    @Test
+    void flatMapEachRefDupesInvokeMapperOnceAndSubscribeOnceOnInner() {
+        Member kfir = new Member("kfir");
+        CountingObservable<String> innerName = new CountingObservable<>(kfir.displayName());
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir, kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(member -> {
+            mapperCalls.incrementAndGet();
+            return innerName;
+        });
+
+        assertEquals(List.of("kfir", "kfir", "kfir", "kfir", "kfir"), names.get());
+        assertEquals(1, mapperCalls.get(), "mapper invoked once per unique source ref");
+        assertEquals(1, innerName.observes, "inner observable subscribed exactly once for all duplicates");
+    }
+
+    @Test
+    void flatMapEachEqualButDistinctInvokesMapperPerOccurrence() {
+        record Token(String id) {}
+
+        Token a = new Token("kfir");
+        Token b = new Token("kfir");
+        Token c = new Token("kfir");
+
+        assertEquals(a, b);
+        assertEquals(a, c);
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Token> list = Observable.list(new ArrayList<>(List.of(a, b, c)));
+        ListObservable<String> names = (ListObservable<String>) list.flatMapEach(token -> {
+            mapperCalls.incrementAndGet();
+            return Observable.immutable(token.id());
+        });
+
+        assertEquals(List.of("kfir", "kfir", "kfir"), names.get());
+        assertEquals(3, mapperCalls.get(),
+                "identity-based bookkeeping invokes mapper once per distinct ref even when refs are .equals");
+    }
+
+    @Test
+    void flatMapEachAddingMoreRefDupesDoesNotReSubscribeOrReInvokeMapper() {
+        Member kfir = new Member("kfir");
+        CountingObservable<String> innerName = new CountingObservable<>(kfir.displayName());
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+        ListObservable<String> names = list.flatMapEach(member -> {
+            mapperCalls.incrementAndGet();
+            return innerName;
+        });
+
+        names.get();
+        int observesAfterInit = innerName.observes;
+        assertEquals(1, mapperCalls.get());
+        assertEquals(1, observesAfterInit);
+
+        list.add(kfir);
+        list.add(kfir);
+        list.add(kfir);
+        names.get();
+
+        assertEquals(1, mapperCalls.get(), "mapper not re-invoked for additional duplicates of an existing ref");
+        assertEquals(observesAfterInit, innerName.observes, "no new subscribe for additional duplicates");
+    }
+
+    @Test
+    void flatMapEachStableGetReturnsCachedWithoutCallingInnerGet() {
+        Member kfir = new Member("kfir");
+        CountingObservable<String> innerName = new CountingObservable<>(kfir.displayName());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(member -> innerName);
+
+        names.get();
+        int innerGetsAfterInit = innerName.gets;
+
+        // multiple stable gets — nothing changed, must hit cached collection
+        List<String> a = names.get();
+        List<String> b = names.get();
+        List<String> c = names.get();
+
+        assertSame(a, b);
+        assertSame(b, c);
+        assertEquals(innerGetsAfterInit, innerName.gets, "stable get() must not re-fetch inner observable");
+    }
+
+    @Test
+    void flatMapEachInnerChangeCallsInnerGetOnceForAllDupes() {
+        Member kfir = new Member("kfir");
+        CountingObservable<String> innerName = new CountingObservable<>(kfir.displayName());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir, kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(member -> innerName);
+
+        names.get();
+        int innerGetsAfterInit = innerName.gets;
+
+        kfir.displayName().set("Kfir Notro");
+        names.get();
+
+        // exactly one fresh inner.get() despite five duplicate occurrences
+        assertEquals(innerGetsAfterInit + 1, innerName.gets,
+                "inner observable.get() invoked once per change, regardless of how many duplicates reference it");
+    }
+
+    @Test
+    void flatMapEachRemovingOneOfManyDupesDoesNotUnsubscribe() {
+        Member kfir = new Member("kfir");
+        CountingObservable<String> innerName = new CountingObservable<>(kfir.displayName());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(member -> innerName);
+
+        names.get();
+        assertEquals(0, innerName.removes);
+
+        list.remove(kfir);
+        names.get();
+
+        assertEquals(0, innerName.removes,
+                "removing one occurrence must not unsubscribe — other occurrences still reference the inner observable");
+    }
+
+    @Test
+    void flatMapEachRemovingAllDupesUnsubscribesOnce() {
+        Member kfir = new Member("kfir");
+        CountingObservable<String> innerName = new CountingObservable<>(kfir.displayName());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(member -> innerName);
+
+        names.get();
+        assertEquals(0, innerName.removes);
+
+        list.clear();
+        names.get();
+
+        assertEquals(1, innerName.removes,
+                "after every reference is gone, the inner observable is unsubscribed exactly once");
+    }
+
+    @Test
+    void flatMapEachReAddingAfterFullRemovalReSubscribesOnce() {
+        Member kfir = new Member("kfir");
+        CountingObservable<String> innerName = new CountingObservable<>(kfir.displayName());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir)));
+        ListObservable<String> names = list.flatMapEach(member -> innerName);
+
+        names.get();
+        assertEquals(1, innerName.observes);
+
+        list.clear();
+        names.get();
+        assertEquals(1, innerName.removes);
+
+        list.add(kfir);
+        list.add(kfir);
+        list.add(kfir);
+        names.get();
+
+        assertEquals(2, innerName.observes,
+                "re-adding triggers a single fresh subscribe, not one per occurrence");
+    }
+
+    @Test
+    void mapEachStableGetReturnsCachedWithoutReInvokingMapper() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of(
+                "kfir", "kfir", "apartium", "kfir"
+        )));
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Integer> lengths = list.mapEach(name -> {
+            mapperCalls.incrementAndGet();
+            return name.length();
+        });
+
+        lengths.get();
+        assertEquals(4, mapperCalls.get(), "first materialization invokes mapper once per occurrence");
+
+        // stable gets — no source change, mapper must not be re-invoked
+        lengths.get();
+        lengths.get();
+        lengths.get();
+        assertEquals(4, mapperCalls.get(), "stable get() must hit cache and not re-invoke the mapper");
+    }
+
+    @Test
+    void mapEachReInvokesMapperPerOccurrenceOnBaseChange() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "kfir")));
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Integer> lengths = list.mapEach(name -> {
+            mapperCalls.incrementAndGet();
+            return name.length();
+        });
+
+        lengths.get();
+        assertEquals(2, mapperCalls.get());
+
+        list.add("kfir");
+        lengths.get();
+
+        // mapEach has no per-element caching: every occurrence is re-mapped after a base change
+        assertEquals(5, mapperCalls.get(),
+                "mapEach re-runs the mapper per occurrence after a base change (no per-element caching)");
+    }
+
+    @Test
+    void filterRefDupesInvokeMapperOnceAndPredicateGetOnce() {
+        Member kfir = new Member("kfir");
+        CountingObservable<Boolean> activePredicate = new CountingObservable<>(kfir.active());
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir, kfir, kfir)));
+        ListObservable<Member> active = list.filter(member -> {
+            mapperCalls.incrementAndGet();
+            return activePredicate;
+        });
+
+        active.get();
+
+        assertEquals(1, mapperCalls.get(), "predicate mapper invoked once per unique source ref");
+        assertEquals(1, activePredicate.observes, "predicate observable subscribed exactly once across all duplicates");
+        assertEquals(1, activePredicate.gets,
+                "predicate.get() invoked once during materialization regardless of duplicate count");
+    }
+
+    @Test
+    void filterEqualButDistinctInvokesPredicateMapperPerOccurrence() {
+        record Token(String id) {}
+
+        Token a = new Token("kfir");
+        Token b = new Token("kfir");
+        Token c = new Token("kfir");
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Token> list = Observable.list(new ArrayList<>(List.of(a, b, c)));
+        ListObservable<Token> filtered = list.filter(token -> {
+            mapperCalls.incrementAndGet();
+            return Observable.immutable(true);
+        });
+
+        filtered.get();
+
+        assertEquals(3, mapperCalls.get(),
+                "identity-based bookkeeping invokes the predicate mapper once per distinct ref");
+    }
+
+    @Test
+    void filterStableGetDoesNotReInvokeMapperOrPredicateGet() {
+        Member kfir = new Member("kfir");
+        CountingObservable<Boolean> activePredicate = new CountingObservable<>(kfir.active());
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir)));
+        ListObservable<Member> active = list.filter(member -> {
+            mapperCalls.incrementAndGet();
+            return activePredicate;
+        });
+
+        active.get();
+        int gets1 = activePredicate.gets;
+        int mapper1 = mapperCalls.get();
+
+        active.get();
+        active.get();
+        active.get();
+
+        assertEquals(mapper1, mapperCalls.get(), "predicate mapper not re-invoked across stable gets");
+        assertEquals(gets1, activePredicate.gets, "predicate.get() not re-invoked across stable gets");
+    }
+
+    @Test
+    void filterPredicateChangeCallsPredicateGetOnceForAllDupes() {
+        Member kfir = new Member("kfir");
+        CountingObservable<Boolean> activePredicate = new CountingObservable<>(kfir.active());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir, kfir, kfir)));
+        ListObservable<Member> active = list.filter(member -> activePredicate);
+
+        active.get();
+        int getsAfterInit = activePredicate.gets;
+
+        kfir.active().set(false);
+        active.get();
+
+        assertEquals(getsAfterInit + 1, activePredicate.gets,
+                "predicate.get() invoked once per change regardless of how many duplicates share it");
+    }
+
+    @Test
+    void filterAddingMoreRefDupesDoesNotReInvokeMapperOrReSubscribe() {
+        Member kfir = new Member("kfir");
+        CountingObservable<Boolean> activePredicate = new CountingObservable<>(kfir.active());
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+        ListObservable<Member> active = list.filter(member -> {
+            mapperCalls.incrementAndGet();
+            return activePredicate;
+        });
+
+        active.get();
+        int observesAfterInit = activePredicate.observes;
+        assertEquals(1, mapperCalls.get());
+        assertEquals(1, observesAfterInit);
+
+        list.add(kfir);
+        list.add(kfir);
+        active.get();
+
+        assertEquals(1, mapperCalls.get(), "mapper not re-invoked for new duplicates of an existing ref");
+        assertEquals(observesAfterInit, activePredicate.observes, "no extra subscribe for new duplicates");
+    }
+
+    @Test
+    void filterRemovingOneDupeDoesNotUnsubscribe() {
+        Member kfir = new Member("kfir");
+        CountingObservable<Boolean> activePredicate = new CountingObservable<>(kfir.active());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir)));
+        ListObservable<Member> active = list.filter(member -> activePredicate);
+
+        active.get();
+        assertEquals(0, activePredicate.removes);
+
+        list.remove(kfir);
+        active.get();
+
+        assertEquals(0, activePredicate.removes,
+                "filter must not unsubscribe while any occurrence still references the predicate observable");
+    }
+
+    @Test
+    void filterRemovingAllDupesUnsubscribesOnce() {
+        Member kfir = new Member("kfir");
+        CountingObservable<Boolean> activePredicate = new CountingObservable<>(kfir.active());
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, kfir, kfir)));
+        ListObservable<Member> active = list.filter(member -> activePredicate);
+
+        active.get();
+        list.clear();
+        active.get();
+
+        assertEquals(1, activePredicate.removes,
+                "filter unsubscribes exactly once when the last occurrence is removed");
+    }
+
+    @Test
+    void flatMapEachDownstreamFiresOnceWhenSharedInnerChangesEvenWithDupes() {
+        MutableObservable<String> shared = Observable.mutable("kfir");
+
+        Member a = new Member("a", shared);
+        Member b = new Member("b", shared);
+        Member c = new Member("c", shared);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(a, b, c, a, b, c)));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        names.get();
+
+        CountingObserver downstream = new CountingObserver();
+        names.observe(downstream);
+
+        shared.set("apartium");
+
+        assertEquals(1, downstream.count,
+                "downstream is flagged dirty exactly once per upstream change, not once per duplicate");
+    }
+
+    @Test
+    void filterDownstreamFiresOnceWhenSharedPredicateChangesEvenWithDupes() {
+        MutableObservable<Boolean> shared = Observable.mutable(true);
+
+        Member a = new Member("a", Observable.mutable("a"), shared);
+        Member b = new Member("b", Observable.mutable("b"), shared);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(a, b, a, b, a, b)));
+        ListObservable<Member> active = list.filter(Member::active);
+        active.get();
+
+        CountingObserver downstream = new CountingObserver();
+        active.observe(downstream);
+
+        shared.set(false);
+
+        assertEquals(1, downstream.count,
+                "filter notifies downstream once per upstream change, regardless of duplicate count");
     }
 
     // ---------------------------------------------------------------------
@@ -923,6 +1724,49 @@ class ListObservableTest {
         public void flagAsDirty(Observable<?> observable) {
             count++;
             last = observable;
+        }
+
+    }
+
+    private static final class CountingObservable<T> implements Observable<T>, Observer {
+
+        final Observable<T> delegate;
+        final java.util.LinkedHashSet<Observer> observers = new java.util.LinkedHashSet<>();
+        int gets;
+        int observes;
+        int removes;
+        boolean bridged;
+
+        CountingObservable(Observable<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public T get() {
+            gets++;
+            return delegate.get();
+        }
+
+        @Override
+        public void observe(Observer observer) {
+            observes++;
+            if (!bridged) {
+                delegate.observe(this);
+                bridged = true;
+            }
+            observers.add(observer);
+        }
+
+        @Override
+        public boolean removeObserver(Observer observer) {
+            removes++;
+            return observers.remove(observer);
+        }
+
+        @Override
+        public void flagAsDirty(Observable<?> observable) {
+            for (Observer observer : observers)
+                observer.flagAsDirty(this);
         }
 
     }

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
@@ -2,10 +2,13 @@ package net.apartium.cocoabeans.state;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ListObservableTest {
 
@@ -34,6 +37,873 @@ class ListObservableTest {
         scores.observe(observer);
         scores.add(100);
         assertTrue(scores.removeObserver(observer));
+    }
+
+    // ---------------------------------------------------------------------
+    // mapEach edge cases
+    // ---------------------------------------------------------------------
+
+    @Test
+    void mapEachOnEmptyListReturnsEmpty() {
+        ListObservable<String> list = Observable.list();
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+
+        assertEquals(List.of(), lengths.get());
+        assertEquals(0, lengths.size().get());
+    }
+
+    @Test
+    void mapEachPreservesOrderAndDuplicates() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of(
+                "kfir", "apartium", "voigon", "kfir", "lior"
+        )));
+
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+
+        // 4, 8, 6, 4, 4 — list keeps duplicates AND insertion order
+        assertEquals(List.of(4, 8, 6, 4, 4), lengths.get());
+        assertEquals(5, lengths.size().get());
+    }
+
+    @Test
+    void mapEachIdentityFunction() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "apartium")));
+        ListObservable<String> identity = list.mapEach(Function.identity());
+
+        assertEquals(List.of("kfir", "apartium"), identity.get());
+    }
+
+    @Test
+    void mapEachReflectsAddRemoveAndAddAtIndex() {
+        ListObservable<String> list = Observable.list();
+        list.add("kfir");
+        list.add("apartium");
+
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+        assertEquals(List.of(4, 8), lengths.get());
+
+        // add(int, E) on the source must propagate
+        list.add(1, "voigon");
+        assertEquals(List.of("kfir", "voigon", "apartium"), list.get());
+        assertEquals(List.of(4, 6, 8), lengths.get());
+
+        // remove by value on source propagates
+        assertTrue(list.remove("voigon"));
+        assertEquals(List.of(4, 8), lengths.get());
+
+        // remove(int) on source propagates
+        list.remove(0);
+        assertEquals(List.of(8), lengths.get());
+    }
+
+    @Test
+    void mapEachReflectsClear() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "apartium")));
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+        assertEquals(List.of(4, 8), lengths.get());
+
+        list.clear();
+        assertEquals(List.of(), lengths.get());
+
+        // clearing an already-empty list should not produce a notification
+        CountingObserver downstream = new CountingObserver();
+        lengths.observe(downstream);
+        list.clear();
+        assertEquals(0, downstream.count, "clearing an already-empty list must not notify");
+    }
+
+    @Test
+    void mapEachReflectsSort() {
+        ListObservable<Integer> list = Observable.list(new ArrayList<>(List.of(3, 1, 4, 1, 5, 9)));
+        ListObservable<Integer> doubled = list.mapEach(n -> n * 2);
+
+        assertEquals(List.of(6, 2, 8, 2, 10, 18), doubled.get());
+
+        list.sort(Comparator.naturalOrder());
+        assertEquals(List.of(1, 1, 3, 4, 5, 9), list.get());
+        assertEquals(List.of(2, 2, 6, 8, 10, 18), doubled.get());
+    }
+
+    @Test
+    void mapEachCachesResultUntilBaseChanges() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "lior")));
+
+        AtomicInteger calls = new AtomicInteger();
+        ListObservable<Integer> lengths = list.mapEach(s -> {
+            calls.incrementAndGet();
+            return s.length();
+        });
+
+        assertEquals(List.of(4, 4), lengths.get());
+        assertEquals(List.of(4, 4), lengths.get());
+        assertEquals(List.of(4, 4), lengths.get());
+        assertEquals(2, calls.get(), "mapper should run once per element on the first get only");
+
+        list.add("voigon");
+        assertEquals(List.of(4, 4, 6), lengths.get());
+        assertEquals(5, calls.get());
+    }
+
+    @Test
+    void mapEachIgnoresFlagAsDirtyFromUnrelatedObservable() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir")));
+
+        AtomicInteger calls = new AtomicInteger();
+        ListObservable<Integer> lengths = list.mapEach(name -> {
+            calls.incrementAndGet();
+            return name.length();
+        });
+
+        assertEquals(List.of(4), lengths.get());
+        assertEquals(1, calls.get());
+
+        CountingObserver downstream = new CountingObserver();
+        lengths.observe(downstream);
+
+        Observer asObserver = (Observer) lengths;
+        MutableObservable<String> unrelated = Observable.mutable("notro");
+        asObserver.flagAsDirty(unrelated);
+
+        assertEquals(0, downstream.count, "unrelated flagAsDirty must not propagate notification");
+        assertEquals(List.of(4), lengths.get());
+        assertEquals(1, calls.get(), "unrelated flagAsDirty must not invalidate the cache");
+    }
+
+    @Test
+    void mapEachNotifiesObserversOnBaseChange() {
+        ListObservable<String> list = Observable.list();
+        list.add("kfir");
+
+        ListObservable<Integer> lengths = list.mapEach(String::length);
+        lengths.get();
+
+        CountingObserver downstream = new CountingObserver();
+        lengths.observe(downstream);
+
+        list.add("apartium");
+        assertEquals(1, downstream.count);
+        assertSame(lengths, downstream.last);
+
+        list.remove("apartium");
+        assertEquals(2, downstream.count);
+
+        assertTrue(lengths.removeObserver(downstream));
+        assertFalse(lengths.removeObserver(downstream));
+    }
+
+    @Test
+    void mapEachChainedMapEach() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "apartium", "voigon")));
+
+        ListObservable<Integer> doubledLengths = list
+                .mapEach(String::length)
+                .mapEach(n -> n * 2);
+
+        assertEquals(List.of(8, 16, 12), doubledLengths.get());
+    }
+
+    @Test
+    void mapEachThenFilterReturnsListObservable() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of(
+                "kfir", "apartium", "voigon", "lior"
+        )));
+
+        ListObservable<Integer> longLengths = list
+                .mapEach(String::length)
+                .filter(n -> Observable.immutable(n >= 6));
+
+        assertEquals(List.of(8, 6), longLengths.get());
+    }
+
+    @Test
+    void mapEachThenFlatMapEach() {
+        MutableObservable<String> kfirSuffix = Observable.mutable("a");
+        MutableObservable<String> liorSuffix = Observable.mutable("b");
+
+        ListObservable<MutableObservable<String>> list = Observable.list(new ArrayList<>(List.of(
+                kfirSuffix, liorSuffix
+        )));
+
+        ListObservable<String> values = list
+                .mapEach(Function.identity())
+                .flatMapEach(o -> o);
+
+        assertEquals(List.of("a", "b"), values.get());
+
+        kfirSuffix.set("c");
+        assertEquals(List.of("c", "b"), values.get());
+    }
+
+    @Test
+    void mapEachUnsupportedListMutationsThrow() {
+        ListObservable<Integer> mapped = Observable.<Integer>list().mapEach(n -> n);
+
+        // inherited from MapElementObservable
+        assertThrows(UnsupportedOperationException.class, () -> mapped.add(1));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.remove((Integer) 1));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, mapped::clear);
+
+        // list-specific overrides
+        assertThrows(UnsupportedOperationException.class, () -> mapped.add(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.sort(Comparator.naturalOrder()));
+    }
+
+    @Test
+    void mapEachWithNullTolerantListAllowsNullMapper() {
+        // The default ListObservable's get() uses List.copyOf which rejects nulls, so we cannot
+        // verify the inverse path with the default implementation. We at least verify NPE is raised.
+        ListObservable<String> list = Observable.list();
+        list.add("kfir");
+
+        ListObservable<String> nulls = list.mapEach(name -> null);
+        assertThrows(NullPointerException.class, nulls::get);
+    }
+
+    // ---------------------------------------------------------------------
+    // flatMapEach edge cases
+    // ---------------------------------------------------------------------
+
+    @Test
+    void flatMapEachOnEmptyListReturnsEmpty() {
+        ListObservable<Member> list = Observable.list();
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+
+        assertEquals(List.of(), names.get());
+        assertEquals(0, names.size().get());
+    }
+
+    @Test
+    void flatMapEachReflectsInnerObservableChange() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        assertEquals(List.of("kfir"), names.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro"), names.get());
+    }
+
+    @Test
+    void flatMapEachDeduplicatesByElementIdentity() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+
+        // FlatMapElementObservable keys innerByElement on the element, so duplicate occurrences
+        // of the same element collapse to a single entry in the mapped output — even on a List.
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, kfir)));
+
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        assertEquals(List.of("kfir", "apartium"), names.get());
+        assertEquals(2, names.size().get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachWithDistinctEqualElementsAlsoDedupes() {
+        // record equality matches when components match — but each Member has its own
+        // observables, so two `new Member("kfir")` calls produce non-equal records.
+        // To exercise equals-based dedup, share the inner observables between two records.
+        MutableObservable<String> sharedName = Observable.mutable("kfir");
+        MutableObservable<Boolean> sharedActive = Observable.mutable(true);
+        Member kfir1 = new Member("kfir", sharedName, sharedActive);
+        Member kfir2 = new Member("kfir", sharedName, sharedActive);
+
+        assertEquals(kfir1, kfir2, "record equality holds when all components are equal");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir1, kfir2)));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+
+        // equals-equal duplicates collapse on the LinkedHashMap key
+        assertEquals(List.of("kfir"), names.get());
+    }
+
+    @Test
+    void flatMapEachReflectsAddAndRemove() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        assertEquals(List.of("kfir"), names.get());
+
+        list.add(apartium);
+        assertEquals(List.of("kfir", "apartium"), names.get());
+
+        list.remove(kfir);
+        assertEquals(List.of("apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachInnerChangeAfterRemoveIsIgnored() {
+        Member kfir = new Member("kfir");
+        Member lior = new Member("lior");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, lior)));
+
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        assertEquals(List.of("kfir", "lior"), names.get());
+
+        list.remove(kfir);
+        assertEquals(List.of("lior"), names.get());
+
+        kfir.displayName().set("ghost");
+        assertEquals(List.of("lior"), names.get(), "inner change for a removed element must not propagate");
+    }
+
+    @Test
+    void flatMapEachReflectsClear() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        assertEquals(List.of("kfir"), names.get());
+
+        list.clear();
+        assertEquals(List.of(), names.get());
+
+        kfir.displayName().set("ghost");
+        assertEquals(List.of(), names.get());
+    }
+
+    @Test
+    void flatMapEachWithSharedInnerObservableTracksAllElements() {
+        MutableObservable<String> shared = Observable.mutable("apartium");
+
+        Member kfir = new Member("kfir", shared);
+        Member lior = new Member("lior", shared);
+
+        // list keeps duplicates; the same shared observable is referenced by two distinct elements
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, lior)));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+
+        // both members share the same inner -> two entries with the same value
+        assertEquals(List.of("apartium", "apartium"), names.get());
+
+        shared.set("voigon");
+        assertEquals(List.of("voigon", "voigon"), names.get());
+    }
+
+    @Test
+    void flatMapEachWithSharedInnerKeepsObservingWhenOnlyOneElementRemoved() {
+        MutableObservable<String> shared = Observable.mutable("apartium");
+
+        Member kfir = new Member("kfir", shared);
+        Member lior = new Member("lior", shared);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, lior)));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        assertEquals(List.of("apartium", "apartium"), names.get());
+
+        list.remove(kfir);
+        assertEquals(List.of("apartium"), names.get());
+
+        shared.set("voigon");
+        assertEquals(List.of("voigon"), names.get(), "shared inner must still update while any element references it");
+    }
+
+    @Test
+    void flatMapEachIsCachedUntilBaseOrInnerChanges() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        ListObservable<String> names = list.flatMapEach(member -> {
+            mapperCalls.incrementAndGet();
+            return member.displayName();
+        });
+
+        assertEquals(List.of("kfir"), names.get());
+        assertEquals(List.of("kfir"), names.get());
+        assertEquals(1, mapperCalls.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro"), names.get());
+        assertEquals(1, mapperCalls.get(), "inner change must not re-invoke the element mapper");
+
+        list.add(new Member("voigon"));
+        assertEquals(List.of("Kfir Notro", "voigon"), names.get());
+        assertEquals(2, mapperCalls.get());
+    }
+
+    @Test
+    void flatMapEachIgnoresFlagAsDirtyFromUnrelatedObservable() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        names.get();
+
+        CountingObserver downstream = new CountingObserver();
+        names.observe(downstream);
+
+        Observer asObserver = (Observer) names;
+        MutableObservable<String> unrelated = Observable.mutable("notro");
+        asObserver.flagAsDirty(unrelated);
+
+        assertEquals(0, downstream.count, "unrelated observable must not trigger downstream notifications");
+    }
+
+    @Test
+    void flatMapEachNotifiesDownstreamOnInnerChange() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        names.get();
+
+        CountingObserver downstream = new CountingObserver();
+        names.observe(downstream);
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(1, downstream.count);
+        assertSame(names, downstream.last);
+        assertEquals(List.of("Kfir Notro"), names.get());
+
+        assertTrue(names.removeObserver(downstream));
+        kfir.displayName().set("Kfir2");
+        assertEquals(1, downstream.count, "removed observer must not be notified");
+    }
+
+    @Test
+    void flatMapEachThenMapEach() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<Integer> nameLengths = list
+                .flatMapEach(Member::displayName)
+                .mapEach(String::length);
+
+        assertEquals(List.of(4, 8), nameLengths.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of(10, 8), nameLengths.get());
+    }
+
+    @Test
+    void flatMapEachThenFlatMapEach() {
+        MutableObservable<MutableObservable<String>> nested =
+                Observable.mutable(Observable.mutable("kfir"));
+
+        ListObservable<MutableObservable<MutableObservable<String>>> list =
+                Observable.list(new ArrayList<>(List.of(nested)));
+
+        ListObservable<String> values = list
+                .flatMapEach(o -> o)
+                .flatMapEach(o -> o);
+
+        assertEquals(List.of("kfir"), values.get());
+
+        nested.get().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro"), values.get());
+
+        nested.set(Observable.mutable("apartium"));
+        assertEquals(List.of("apartium"), values.get());
+    }
+
+    @Test
+    void flatMapEachThenFilter() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> startsWithA = list
+                .flatMapEach(Member::displayName)
+                .filter(name -> Observable.immutable(name.startsWith("a")));
+
+        assertEquals(List.of("apartium"), startsWithA.get());
+
+        kfir.displayName().set("aaaa-kfir");
+        assertEquals(List.of("aaaa-kfir", "apartium"), startsWithA.get());
+    }
+
+    @Test
+    void flatMapEachUnsupportedListMutationsThrow() {
+        ListObservable<Member> list = Observable.list();
+        ListObservable<String> mapped = list.flatMapEach(Member::displayName);
+
+        // inherited from FlatMapElementObservable
+        assertThrows(UnsupportedOperationException.class, () -> mapped.add("x"));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.remove("x"));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, mapped::clear);
+
+        // list-specific overrides
+        assertThrows(UnsupportedOperationException.class, () -> mapped.add(0, "x"));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.sort(Comparator.naturalOrder()));
+    }
+
+    @Test
+    void flatMapEachReAddingElementAfterClearWorks() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        ListObservable<String> names = list.flatMapEach(Member::displayName);
+        assertEquals(List.of("kfir"), names.get());
+
+        list.clear();
+        assertEquals(List.of(), names.get());
+
+        list.add(kfir);
+        assertEquals(List.of("kfir"), names.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro"), names.get());
+    }
+
+    @Test
+    void flatMapEachWithNullMapperResultThrowsBecauseListCopyOfRejectsNull() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+
+        // The default ListObservableImpl uses List.copyOf, which does not allow nulls. The
+        // FlatMapElementObservable adds null to the staging collection when the inner is null,
+        // so this exercises the `inner == null` branch and the fact that the standard list
+        // chain rejects nulls at copyOf time.
+        ListObservable<String> names = list.flatMapEach(member -> null);
+        assertThrows(NullPointerException.class, names::get);
+    }
+
+    // ---------------------------------------------------------------------
+    // filter edge cases
+    // ---------------------------------------------------------------------
+
+    @Test
+    void filterOnEmptyList() {
+        ListObservable<String> list = Observable.list();
+        ListObservable<String> filtered = list.filter(s -> Observable.immutable(true));
+
+        assertEquals(List.of(), filtered.get());
+        assertEquals(0, filtered.size().get());
+    }
+
+    @Test
+    void filterAllTrueReturnsEverythingInOrder() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "apartium", "voigon")));
+        ListObservable<String> filtered = list.filter(s -> Observable.immutable(true));
+
+        assertEquals(List.of("kfir", "apartium", "voigon"), filtered.get());
+    }
+
+    @Test
+    void filterAllFalseReturnsEmpty() {
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "apartium")));
+        ListObservable<String> filtered = list.filter(s -> Observable.immutable(false));
+
+        assertEquals(List.of(), filtered.get());
+    }
+
+    @Test
+    void filterPreservesOrderAndDuplicates() {
+        ListObservable<Integer> list = Observable.list(new ArrayList<>(List.of(1, 2, 3, 4, 5, 6, 4, 2)));
+        ListObservable<Integer> evens = list.filter(n -> Observable.immutable(n % 2 == 0));
+
+        assertEquals(List.of(2, 4, 6, 4, 2), evens.get());
+    }
+
+    @Test
+    void filterTogglingPredicateAddsAndRemovesElement() {
+        Member kfir = new Member("kfir");
+        Member lior = new Member("lior");
+        lior.active().set(false);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, lior)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir), active.get());
+
+        lior.active().set(true);
+        assertEquals(List.of(kfir, lior), active.get());
+
+        kfir.active().set(false);
+        assertEquals(List.of(lior), active.get());
+    }
+
+    @Test
+    void filterAddingElementWithTruePredicateIncludesIt() {
+        ListObservable<Member> list = Observable.list();
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(), active.get());
+
+        Member kfir = new Member("kfir");
+        list.add(kfir);
+        assertEquals(List.of(kfir), active.get());
+    }
+
+    @Test
+    void filterAddingElementWithFalsePredicateExcludesIt() {
+        ListObservable<Member> list = Observable.list();
+        ListObservable<Member> active = list.filter(Member::active);
+
+        Member kfir = new Member("kfir");
+        kfir.active().set(false);
+        list.add(kfir);
+        assertEquals(List.of(), active.get());
+
+        kfir.active().set(true);
+        assertEquals(List.of(kfir), active.get());
+    }
+
+    @Test
+    void filterRemovingElementRemovesItFromResult() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<Member> active = list.filter(Member::active);
+        assertEquals(List.of(kfir, apartium), active.get());
+
+        list.remove(kfir);
+        assertEquals(List.of(apartium), active.get());
+    }
+
+    @Test
+    void filterChainedFilter() {
+        ListObservable<Integer> list = Observable.list(new ArrayList<>(List.of(1, 2, 3, 4, 5, 6, 7, 8)));
+
+        ListObservable<Integer> evenAndLarge = list
+                .filter(n -> Observable.immutable(n % 2 == 0))
+                .filter(n -> Observable.immutable(n >= 4));
+
+        assertEquals(List.of(4, 6, 8), evenAndLarge.get());
+    }
+
+    @Test
+    void filterThenMapEach() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> activeIds = list
+                .filter(Member::active)
+                .mapEach(Member::id);
+
+        assertEquals(List.of("kfir", "apartium"), activeIds.get());
+    }
+
+    @Test
+    void filterThenFlatMapEach() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        apartium.active().set(false);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> activeNames = list
+                .filter(Member::active)
+                .flatMapEach(Member::displayName);
+
+        assertEquals(List.of("kfir"), activeNames.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro"), activeNames.get());
+
+        apartium.active().set(true);
+        assertEquals(List.of("Kfir Notro", "apartium"), activeNames.get());
+    }
+
+    @Test
+    void filterCachedWhenNoNetChange() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<Member> active = list.filter(Member::active);
+        List<Member> initial = active.get();
+        assertEquals(List.of(kfir, apartium), initial);
+
+        kfir.active().set(false);
+        kfir.active().set(true);
+        List<Member> after = active.get();
+        assertEquals(initial, after, "net-zero toggle must produce the same membership");
+
+        assertSame(after, active.get(), "second get() with no further changes must return the same cached snapshot");
+    }
+
+    @Test
+    void filterIgnoresFlagAsDirtyFromUnrelatedObservable() {
+        Member kfir = new Member("kfir");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir)));
+        ListObservable<Member> active = list.filter(Member::active);
+        active.get();
+
+        CountingObserver downstream = new CountingObserver();
+        active.observe(downstream);
+
+        Observer asObserver = (Observer) active;
+        MutableObservable<Boolean> unrelated = Observable.mutable(true);
+        asObserver.flagAsDirty(unrelated);
+
+        assertEquals(0, downstream.count, "unrelated observable must not trigger filter notifications");
+    }
+
+    @Test
+    void filterSizeReflectsFilteredCount() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        Member voigon = new Member("voigon");
+        voigon.active().set(false);
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, voigon)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(2, active.size().get());
+
+        voigon.active().set(true);
+        assertEquals(3, active.size().get());
+
+        list.clear();
+        assertEquals(0, active.size().get());
+    }
+
+    @Test
+    void filterTwoArgOverloadMapsThenTests() {
+        Member kfir = new Member("kfir");
+        Member lior = new Member("lior");
+        Member apartium = new Member("apartium");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, lior, apartium)));
+
+        ListObservable<Member> startsWithVowel = list.filter(
+                Member::displayName,
+                name -> "aeiou".indexOf(name.charAt(0)) >= 0
+        );
+
+        assertEquals(List.of(apartium), startsWithVowel.get());
+
+        // when an element flips into the filter via incremental update, FilterObservable's
+        // updateFlagged path appends it to the cached list rather than re-running from
+        // base order — so the order here reflects the incremental-update behavior.
+        kfir.displayName().set("orion");
+        assertEquals(List.of(apartium, kfir), startsWithVowel.get());
+    }
+
+    @Test
+    void filterUnsupportedListMutationsThrow() {
+        ListObservable<Integer> filtered = Observable.<Integer>list().filter(n -> Observable.immutable(true));
+
+        // inherited from FilterObservable
+        assertThrows(UnsupportedOperationException.class, () -> filtered.add(1));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.remove((Integer) 1));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.addAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.removeAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.removeIf(n -> true));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, filtered::clear);
+
+        // list-specific overrides on ListFilterObservable
+        assertThrows(UnsupportedOperationException.class, () -> filtered.add(0, 1));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.sort(Comparator.naturalOrder()));
+    }
+
+    @Test
+    void filterRemovingElementWhileShufflingPredicate() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        Member voigon = new Member("voigon");
+
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, voigon)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir, apartium, voigon), active.get());
+
+        // toggle a flag, then change the base before the next get()
+        voigon.active().set(false);
+        list.remove(apartium);
+
+        // checkAndUpdateBase should run because base changed; flagged state must be reconciled
+        assertEquals(List.of(kfir), active.get());
+    }
+
+    @Test
+    void filterUpdatePathHandlesIncrementalToggleWithoutRebuildingBase() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+        ListObservable<Member> active = list.filter(Member::active);
+
+        assertEquals(List.of(kfir, apartium), active.get());
+
+        kfir.active().set(false);
+        assertEquals(List.of(apartium), active.get());
+
+        // re-adding kfir via the incremental updateFlagged path appends to the end of the
+        // cached list rather than restoring source order — a documented quirk of the
+        // current implementation that we lock down here.
+        kfir.active().set(true);
+        assertEquals(List.of(apartium, kfir), active.get());
+    }
+
+    @Test
+    void filterSharedFilterObservableForMultipleElements() {
+        Observable<Boolean> alwaysTrue = Observable.immutable(true);
+
+        ListObservable<String> list = Observable.list(new ArrayList<>(List.of("kfir", "apartium", "voigon")));
+        ListObservable<String> filtered = list.filter(name -> alwaysTrue);
+
+        assertEquals(List.of("kfir", "apartium", "voigon"), filtered.get());
+
+        list.add("notro");
+        assertEquals(List.of("kfir", "apartium", "voigon", "notro"), filtered.get());
+
+        list.remove("kfir");
+        assertEquals(List.of("apartium", "voigon", "notro"), filtered.get());
+    }
+
+    @Test
+    void filterAfterSortReflectsNewOrder() {
+        ListObservable<Integer> list = Observable.list(new ArrayList<>(List.of(5, 1, 4, 2, 3)));
+        ListObservable<Integer> evens = list.filter(n -> Observable.immutable(n % 2 == 0));
+
+        assertEquals(List.of(4, 2), evens.get());
+
+        list.sort(Comparator.naturalOrder());
+        assertEquals(List.of(2, 4), evens.get());
+    }
+
+    // ---------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------
+
+    private record Member(
+            String id,
+            MutableObservable<String> displayName,
+            MutableObservable<Boolean> active
+    ) {
+
+        Member(String id) {
+            this(id, Observable.mutable(id), Observable.mutable(true));
+        }
+
+        Member(String id, MutableObservable<String> displayName) {
+            this(id, displayName, Observable.mutable(true));
+        }
+
+    }
+
+    private static final class CountingObserver implements Observer {
+
+        int count;
+        Observable<?> last;
+
+        @Override
+        public void flagAsDirty(Observable<?> observable) {
+            count++;
+            last = observable;
+        }
+
     }
 
 }

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/ListObservableTest.java
@@ -290,27 +290,28 @@ class ListObservableTest {
     }
 
     @Test
-    void flatMapEachDeduplicatesByElementIdentity() {
+    void flatMapEachPreservesDuplicateOccurrencesInList() {
         Member kfir = new Member("kfir");
         Member apartium = new Member("apartium");
 
-        // FlatMapElementObservable keys innerByElement on the element, so duplicate occurrences
-        // of the same element collapse to a single entry in the mapped output — even on a List.
+        // The same element instance appearing multiple times in the source list must
+        // produce one mapped entry per occurrence. Subscription bookkeeping is still
+        // deduped — the inner observable is observed once per unique element.
         ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir, apartium, kfir)));
 
         ListObservable<String> names = list.flatMapEach(Member::displayName);
-        assertEquals(List.of("kfir", "apartium"), names.get());
-        assertEquals(2, names.size().get());
+        assertEquals(List.of("kfir", "apartium", "kfir"), names.get());
+        assertEquals(3, names.size().get());
 
+        // a single inner change reflects in every occurrence of the element
         kfir.displayName().set("Kfir Notro");
-        assertEquals(List.of("Kfir Notro", "apartium"), names.get());
+        assertEquals(List.of("Kfir Notro", "apartium", "Kfir Notro"), names.get());
     }
 
     @Test
-    void flatMapEachWithDistinctEqualElementsAlsoDedupes() {
-        // record equality matches when components match — but each Member has its own
-        // observables, so two `new Member("kfir")` calls produce non-equal records.
-        // To exercise equals-based dedup, share the inner observables between two records.
+    void flatMapEachPreservesEqualButDistinctOccurrencesInList() {
+        // Two records that compare equal (same components) still produce one
+        // mapped entry per occurrence in the source list.
         MutableObservable<String> sharedName = Observable.mutable("kfir");
         MutableObservable<Boolean> sharedActive = Observable.mutable(true);
         Member kfir1 = new Member("kfir", sharedName, sharedActive);
@@ -321,8 +322,10 @@ class ListObservableTest {
         ListObservable<Member> list = Observable.list(new ArrayList<>(List.of(kfir1, kfir2)));
         ListObservable<String> names = list.flatMapEach(Member::displayName);
 
-        // equals-equal duplicates collapse on the LinkedHashMap key
-        assertEquals(List.of("kfir"), names.get());
+        assertEquals(List.of("kfir", "kfir"), names.get());
+
+        sharedName.set("Kfir Notro");
+        assertEquals(List.of("Kfir Notro", "Kfir Notro"), names.get());
     }
 
     @Test

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/MapElementObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/MapElementObservableTest.java
@@ -1,0 +1,199 @@
+package net.apartium.cocoabeans.state;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MapElementObservableTest {
+
+    @Test
+    void mapEachShouldMapExistingElements() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir"),
+                new GamePlayer(UUID.randomUUID(), "Apartium")
+        )));
+
+        ListObservable<String> names = players.mapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+    }
+
+    @Test
+    void mapEachShouldUpdateWhenElementIsAdded() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir")
+        )));
+
+        ListObservable<String> names = players.mapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir"), names.get());
+
+        players.add(new GamePlayer(UUID.randomUUID(), "Apartium"));
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+    }
+
+    @Test
+    void mapEachShouldUpdateWhenElementIsRemoved() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), "Kfir");
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), "Apartium");
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> names = players.mapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+
+        players.remove(kfir);
+
+        assertEquals(List.of("Apartium"), names.get());
+    }
+
+    @Test
+    void mapEachShouldUpdateWhenCollectionIsCleared() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir"),
+                new GamePlayer(UUID.randomUUID(), "Apartium")
+        )));
+
+        ListObservable<String> names = players.mapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+
+        players.clear();
+
+        assertEquals(List.of(), names.get());
+    }
+
+    @Test
+    void mapEachShouldCacheUntilBaseChanges() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir")
+        )));
+
+        AtomicInteger calls = new AtomicInteger();
+
+        ListObservable<String> names = players.mapEach(player -> {
+            calls.incrementAndGet();
+            return player.name();
+        });
+
+        assertEquals(List.of("Kfir"), names.get());
+        assertEquals(List.of("Kfir"), names.get());
+        assertEquals(List.of("Kfir"), names.get());
+
+        assertEquals(1, calls.get());
+
+        players.add(new GamePlayer(UUID.randomUUID(), "Apartium"));
+
+        assertEquals(List.of("Kfir", "Apartium"), names.get());
+
+        assertEquals(3, calls.get());
+    }
+
+    @Test
+    void mapEachShouldExposeMappedSize() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir")
+        )));
+
+        ListObservable<String> names = players.mapEach(GamePlayer::name);
+
+        assertEquals(1, names.size().get());
+
+        players.add(new GamePlayer(UUID.randomUUID(), "Apartium"));
+
+        assertEquals(2, names.size().get());
+
+        players.clear();
+
+        assertEquals(0, names.size().get());
+    }
+
+    @Test
+    void mapEachShouldNotifyObserversWhenBaseChanges() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir")
+        )));
+
+        ListObservable<String> names = players.mapEach(GamePlayer::name);
+
+        TestObserver observer = new TestObserver();
+        names.observe(observer);
+
+        players.add(new GamePlayer(UUID.randomUUID(), "Apartium"));
+
+        assertTrue(observer.dirty);
+        assertSame(names, observer.observable);
+    }
+
+    @Test
+    void mapEachShouldWorkAfterFilter() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), "Kfir", true);
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), "Apartium", false);
+
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(kfir, apartium)));
+
+        ListObservable<String> aliveNames = players
+                .filter(player -> Observable.immutable(player.alive()))
+                .mapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir"), aliveNames.get());
+    }
+
+    @Test
+    void mapEachShouldWorkBeforeFilter() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir"),
+                new GamePlayer(UUID.randomUUID(), "Apartium")
+        )));
+
+        ListObservable<String> namesStartingWithA = players
+                .mapEach(GamePlayer::name)
+                .filter(name -> Observable.immutable(name.startsWith("A")));
+
+        assertEquals(List.of("Apartium"), new ArrayList<>(namesStartingWithA.get()));
+    }
+
+    @Test
+    void mapEachShouldSupportChaining() {
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                new GamePlayer(UUID.randomUUID(), "Kfir"),
+                new GamePlayer(UUID.randomUUID(), "Apartium")
+        )));
+
+        ListObservable<Integer> nameLengths = players
+                .mapEach(GamePlayer::name)
+                .mapEach(String::length);
+
+        assertEquals(List.of(4, 8), nameLengths.get());
+    }
+
+    private record GamePlayer(UUID uuid, String name, boolean alive) {
+
+        private GamePlayer(UUID uuid, String name) {
+            this(uuid, name, true);
+        }
+
+    }
+
+    private static class TestObserver implements Observer {
+
+        private boolean dirty;
+        private Observable<?> observable;
+
+        @Override
+        public void flagAsDirty(Observable<?> observable) {
+            this.dirty = true;
+            this.observable = observable;
+        }
+
+    }
+
+}

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/MapElementObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/MapElementObservableTest.java
@@ -2,10 +2,7 @@ package net.apartium.cocoabeans.state;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -159,6 +156,41 @@ class MapElementObservableTest {
                 .filter(name -> Observable.immutable(name.startsWith("A")));
 
         assertEquals(List.of("Apartium"), new ArrayList<>(namesStartingWithA.get()));
+    }
+
+    @Test
+    void mapEachDupe() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), "Kfir");
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), "Apartium");
+        ListObservable<GamePlayer> players = Observable.list(new ArrayList<>(List.of(
+                kfir,
+                apartium,
+                kfir,
+                kfir,
+                apartium
+        )));
+
+        ListObservable<String> names = players.mapEach(GamePlayer::name);
+
+        assertEquals(List.of("Kfir", "Apartium", "Kfir", "Kfir", "Apartium"), names.get());
+    }
+
+    @Test
+    void mapEachSetNoDupe() {
+        GamePlayer kfir = new GamePlayer(UUID.randomUUID(), "Kfir");
+        GamePlayer apartium = new GamePlayer(UUID.randomUUID(), "Apartium");
+
+        SetObservable<GamePlayer> players = Observable.set(new HashSet<>(List.of(
+                kfir,
+                apartium,
+                kfir,
+                kfir,
+                apartium
+        )));
+
+        SetObservable<String> names = players.mapEach(GamePlayer::name);
+
+        assertEquals(Set.of("Kfir", "Apartium"), names.get());
     }
 
     @Test

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/SetObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/SetObservableTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -306,6 +307,905 @@ class SetObservableTest {
                 .map(values -> values.stream().sorted().toList().toString());
 
         assertEquals("[20, 30]", filtered.get());
+    }
+
+    // ---------------------------------------------------------------------
+    // mapEach edge cases
+    // ---------------------------------------------------------------------
+
+    @Test
+    void mapEachOnEmptySetReturnsEmpty() {
+        SetObservable<String> set = Observable.set();
+        SetObservable<Integer> lengths = set.mapEach(String::length);
+
+        assertEquals(Set.of(), lengths.get());
+        assertEquals(0, lengths.size().get());
+    }
+
+    @Test
+    void mapEachReflectsBaseAddAndRemove() {
+        SetObservable<String> set = Observable.set();
+        set.addAll(List.of("kfir", "apartium"));
+
+        SetObservable<Integer> lengths = set.mapEach(String::length);
+        assertEquals(Set.of(4, 8), lengths.get());
+
+        set.add("voigon");
+        assertEquals(Set.of(4, 6, 8), lengths.get());
+
+        set.remove("kfir");
+        assertEquals(Set.of(6, 8), lengths.get());
+    }
+
+    @Test
+    void mapEachDeduplicatesWhenMappingProducesSameValue() {
+        SetObservable<String> set = Observable.set(new HashSet<>(Set.of("kfir", "lior", "voigon", "notro")));
+
+        // every name maps to the constant 1 -> set should have exactly one element
+        SetObservable<Integer> ones = set.mapEach(name -> 1);
+
+        assertEquals(Set.of(1), ones.get());
+        assertEquals(1, ones.size().get());
+    }
+
+    @Test
+    void mapEachIdentityFunctionPreservesElements() {
+        SetObservable<String> set = Observable.set(new HashSet<>(Set.of("kfir", "apartium")));
+        SetObservable<String> identity = set.mapEach(Function.identity());
+
+        assertEquals(Set.of("kfir", "apartium"), identity.get());
+    }
+
+    @Test
+    void mapEachCachesResultUntilBaseChanges() {
+        SetObservable<String> set = Observable.set();
+        set.addAll(List.of("kfir", "lior"));
+
+        AtomicInteger calls = new AtomicInteger();
+        SetObservable<Integer> lengths = set.mapEach(name -> {
+            calls.incrementAndGet();
+            return name.length();
+        });
+
+        Set<Integer> first = lengths.get();
+        Set<Integer> second = lengths.get();
+        Set<Integer> third = lengths.get();
+
+        assertEquals(first, second);
+        assertEquals(second, third);
+        assertEquals(2, calls.get(), "mapper should run once per element on the first get only");
+
+        set.add("voigon");
+        assertEquals(Set.of(4, 6), Set.copyOf(lengths.get())); // 4 == "kfir"/"lior" (deduped) + 6
+        assertEquals(5, calls.get());
+    }
+
+    @Test
+    void mapEachAddingDuplicateBaseElementDoesNotInvalidateCache() {
+        SetObservable<String> set = Observable.set();
+        set.add("kfir");
+
+        AtomicInteger calls = new AtomicInteger();
+        SetObservable<Integer> lengths = set.mapEach(s -> {
+            calls.incrementAndGet();
+            return s.length();
+        });
+
+        assertEquals(Set.of(4), lengths.get());
+        assertEquals(1, calls.get());
+
+        // adding a duplicate to the underlying set returns false and does not notify
+        assertFalse(set.add("kfir"));
+        assertEquals(Set.of(4), lengths.get());
+        assertEquals(1, calls.get(), "mapper should not be re-invoked when the base set didn't actually change");
+    }
+
+    @Test
+    void mapEachReflectsClear() {
+        SetObservable<String> set = Observable.set();
+        set.addAll(List.of("kfir", "apartium", "voigon"));
+
+        SetObservable<Integer> lengths = set.mapEach(String::length);
+        assertEquals(Set.of(4, 8, 6), lengths.get());
+
+        set.clear();
+        assertEquals(Set.of(), lengths.get());
+        assertEquals(0, lengths.size().get());
+    }
+
+    @Test
+    void mapEachIgnoresFlagAsDirtyFromUnrelatedObservable() {
+        SetObservable<String> set = Observable.set();
+        set.add("kfir");
+
+        AtomicInteger calls = new AtomicInteger();
+        SetObservable<Integer> lengths = set.mapEach(name -> {
+            calls.incrementAndGet();
+            return name.length();
+        });
+        assertEquals(Set.of(4), lengths.get());
+        assertEquals(1, calls.get());
+
+        Observer asObserver = (Observer) lengths;
+        MutableObservable<String> unrelated = Observable.mutable("notro");
+
+        CountingObserver downstream = new CountingObserver();
+        lengths.observe(downstream);
+
+        asObserver.flagAsDirty(unrelated);
+
+        assertEquals(0, downstream.count, "unrelated flagAsDirty must not propagate notification");
+        assertEquals(Set.of(4), lengths.get());
+        assertEquals(1, calls.get(), "unrelated flagAsDirty must not invalidate the cache");
+    }
+
+    @Test
+    void mapEachNotifiesObserversOnlyOnBaseChange() {
+        SetObservable<String> set = Observable.set();
+        set.add("kfir");
+
+        SetObservable<Integer> lengths = set.mapEach(String::length);
+        lengths.get();
+
+        CountingObserver downstream = new CountingObserver();
+        lengths.observe(downstream);
+
+        set.add("apartium");
+        assertEquals(1, downstream.count);
+        assertSame(lengths, downstream.last);
+
+        set.remove("apartium");
+        assertEquals(2, downstream.count);
+
+        // no-op remove should not notify
+        assertFalse(set.remove("voigon"));
+        assertEquals(2, downstream.count);
+
+        assertTrue(lengths.removeObserver(downstream));
+        assertFalse(lengths.removeObserver(downstream));
+    }
+
+    @Test
+    void mapEachSizeReflectsBaseDedupedCount() {
+        SetObservable<String> set = Observable.set();
+        SetObservable<Integer> lengths = set.mapEach(String::length);
+
+        assertEquals(0, lengths.size().get());
+
+        set.add("kfir");
+        assertEquals(1, lengths.size().get());
+
+        // "lior" maps to length 4 — same as "kfir" — the mapped set still dedupes
+        set.add("lior");
+        assertEquals(1, lengths.size().get());
+
+        set.add("apartium");
+        assertEquals(2, lengths.size().get());
+
+        set.clear();
+        assertEquals(0, lengths.size().get());
+    }
+
+    @Test
+    void mapEachChainedMapEach() {
+        SetObservable<String> set = Observable.set(new HashSet<>(Set.of("kfir", "apartium")));
+
+        SetObservable<Integer> doubledLength = set
+                .mapEach(String::length)
+                .mapEach(n -> n * 2);
+
+        assertEquals(Set.of(8, 16), doubledLength.get());
+    }
+
+    @Test
+    void mapEachThenFilterReturnsSetObservable() {
+        SetObservable<String> set = Observable.set(new HashSet<>(Set.of("kfir", "apartium", "voigon", "lior")));
+
+        SetObservable<Integer> longLengths = set
+                .mapEach(String::length)
+                .filter(n -> Observable.immutable(n >= 6));
+
+        assertEquals(Set.of(6, 8), longLengths.get());
+    }
+
+    @Test
+    void mapEachThenFlatMapEach() {
+        MutableObservable<String> kfirSuffix = Observable.mutable("a");
+        MutableObservable<String> liorSuffix = Observable.mutable("b");
+
+        SetObservable<MutableObservable<String>> set =
+                Observable.set(new HashSet<>(Set.of(kfirSuffix, liorSuffix)));
+
+        // mapEach (identity) then flatMapEach to expose the inner
+        SetObservable<String> values = set
+                .mapEach(Function.identity())
+                .flatMapEach(o -> o);
+
+        assertEquals(Set.of("a", "b"), values.get());
+
+        kfirSuffix.set("c");
+        assertEquals(Set.of("c", "b"), values.get());
+    }
+
+    @Test
+    void mapEachUnsupportedMutationsThrow() {
+        SetObservable<Integer> mapped = Observable.<Integer>set().mapEach(n -> n);
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.add(1));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.remove(1));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, mapped::clear);
+    }
+
+    @Test
+    void mapEachWithLinkedHashSetPreservesInsertionOrder() {
+        SetObservable<String> set = Observable.set(
+                new LinkedHashSet<>(),
+                col -> Collections.unmodifiableSet(new LinkedHashSet<>(col)),
+                LinkedHashSet::new
+        );
+        set.add("kfir");
+        set.add("apartium");
+        set.add("voigon");
+
+        SetObservable<String> upper = set.mapEach(String::toUpperCase);
+
+        // verify iteration order through the cast chain
+        List<String> ordered = new ArrayList<>(upper.get());
+        assertEquals(List.of("KFIR", "APARTIUM", "VOIGON"), ordered);
+    }
+
+    @Test
+    void mapEachWithNullTolerantSetAllowsNullMapper() {
+        SetObservable<String> set = Observable.set(
+                new HashSet<>(),
+                col -> {
+                    Set<String> copy = new HashSet<>();
+                    copy.addAll(col);
+                    return Collections.unmodifiableSet(copy);
+                },
+                HashSet::new
+        );
+        set.add("kfir");
+
+        SetObservable<String> nulls = set.mapEach(name -> null);
+
+        Set<String> snapshot = nulls.get();
+        assertEquals(1, snapshot.size());
+        assertTrue(snapshot.contains(null));
+    }
+
+    @Test
+    void mapEachWithDefaultSetCopyOfRejectsNullMapper() {
+        SetObservable<String> set = Observable.set();
+        set.add("kfir");
+
+        SetObservable<String> nulls = set.mapEach(name -> null);
+        assertThrows(NullPointerException.class, nulls::get);
+    }
+
+    // ---------------------------------------------------------------------
+    // flatMapEach edge cases
+    // ---------------------------------------------------------------------
+
+    @Test
+    void flatMapEachOnEmptySetReturnsEmpty() {
+        SetObservable<Member> set = Observable.set();
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+
+        assertEquals(Set.of(), names.get());
+        assertEquals(0, names.size().get());
+    }
+
+    @Test
+    void flatMapEachReflectsInnerObservableChange() {
+        Member kfir = new Member("kfir");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir)));
+
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+        assertEquals(Set.of("kfir"), names.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(Set.of("Kfir Notro"), names.get());
+    }
+
+    @Test
+    void flatMapEachReflectsBaseAddAndRemove() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir)));
+
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+        assertEquals(Set.of("kfir"), names.get());
+
+        set.add(apartium);
+        assertEquals(Set.of("kfir", "apartium"), names.get());
+
+        set.remove(kfir);
+        assertEquals(Set.of("apartium"), names.get());
+    }
+
+    @Test
+    void flatMapEachReflectsClear() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+        assertEquals(Set.of("kfir", "apartium"), names.get());
+
+        set.clear();
+        assertEquals(Set.of(), names.get());
+
+        // mutating an inner that was previously tracked must not bring it back
+        kfir.displayName().set("ZOMBIE");
+        assertEquals(Set.of(), names.get());
+    }
+
+    @Test
+    void flatMapEachInnerChangeAfterRemoveIsIgnored() {
+        Member kfir = new Member("kfir");
+        Member lior = new Member("lior");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, lior)));
+
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+        assertEquals(Set.of("kfir", "lior"), names.get());
+
+        set.remove(kfir);
+        assertEquals(Set.of("lior"), names.get());
+
+        kfir.displayName().set("ghost");
+        assertEquals(Set.of("lior"), names.get(), "inner change for a removed element must not propagate");
+    }
+
+    @Test
+    void flatMapEachWithSharedInnerObservableTracksAllElements() {
+        MutableObservable<String> shared = Observable.mutable("apartium");
+
+        Member kfir = new Member("kfir", shared);
+        Member lior = new Member("lior", shared);
+
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, lior)));
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+
+        // both members route to the same observable -> one shared value -> deduped to one entry
+        assertEquals(Set.of("apartium"), names.get());
+
+        shared.set("voigon");
+        assertEquals(Set.of("voigon"), names.get());
+    }
+
+    @Test
+    void flatMapEachWithSharedInnerKeepsObservingWhenOnlyOneElementRemoved() {
+        MutableObservable<String> shared = Observable.mutable("apartium");
+
+        Member kfir = new Member("kfir", shared);
+        Member lior = new Member("lior", shared);
+
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, lior)));
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+        assertEquals(Set.of("apartium"), names.get());
+
+        // removing kfir leaves lior still depending on shared
+        set.remove(kfir);
+        assertEquals(Set.of("apartium"), names.get());
+
+        shared.set("voigon");
+        assertEquals(Set.of("voigon"), names.get(), "shared inner must still update while any element references it");
+    }
+
+    @Test
+    void flatMapEachIsCachedUntilBaseOrInnerChanges() {
+        Member kfir = new Member("kfir");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir)));
+
+        AtomicInteger mapperCalls = new AtomicInteger();
+        SetObservable<String> names = set.flatMapEach(member -> {
+            mapperCalls.incrementAndGet();
+            return member.displayName();
+        });
+
+        assertEquals(Set.of("kfir"), names.get());
+        assertEquals(Set.of("kfir"), names.get());
+        assertEquals(1, mapperCalls.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(Set.of("Kfir Notro"), names.get());
+        assertEquals(1, mapperCalls.get(), "inner change must not re-invoke the element mapper");
+
+        set.add(new Member("voigon"));
+        assertEquals(Set.of("Kfir Notro", "voigon"), names.get());
+        assertEquals(2, mapperCalls.get());
+    }
+
+    @Test
+    void flatMapEachIgnoresFlagAsDirtyFromUnrelatedObservable() {
+        Member kfir = new Member("kfir");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir)));
+
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+        names.get();
+
+        CountingObserver downstream = new CountingObserver();
+        names.observe(downstream);
+
+        Observer asObserver = (Observer) names;
+        MutableObservable<String> unrelated = Observable.mutable("notro");
+        asObserver.flagAsDirty(unrelated);
+
+        assertEquals(0, downstream.count, "unrelated observable must not trigger downstream notifications");
+    }
+
+    @Test
+    void flatMapEachNotifiesDownstreamOnInnerChange() {
+        Member kfir = new Member("kfir");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir)));
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+
+        names.get();
+
+        CountingObserver downstream = new CountingObserver();
+        names.observe(downstream);
+
+        kfir.displayName().set("Kfir Notro");
+
+        assertEquals(1, downstream.count);
+        assertSame(names, downstream.last);
+        assertEquals(Set.of("Kfir Notro"), names.get());
+
+        assertTrue(names.removeObserver(downstream));
+        kfir.displayName().set("Kfir2");
+        assertEquals(1, downstream.count, "removed observer must not be notified");
+    }
+
+    @Test
+    void flatMapEachThenMapEachChain() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<Integer> nameLengths = set
+                .flatMapEach(Member::displayName)
+                .mapEach(String::length);
+
+        assertEquals(Set.of(4, 8), nameLengths.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(Set.of(10, 8), nameLengths.get());
+    }
+
+    @Test
+    void flatMapEachThenFlatMapEachChain() {
+        MutableObservable<MutableObservable<String>> nested =
+                Observable.mutable(Observable.mutable("kfir"));
+
+        SetObservable<MutableObservable<MutableObservable<String>>> set =
+                Observable.set(new HashSet<>(Set.of(nested)));
+
+        SetObservable<String> values = set
+                .flatMapEach(o -> o)
+                .flatMapEach(o -> o);
+
+        assertEquals(Set.of("kfir"), values.get());
+
+        nested.get().set("Kfir Notro");
+        assertEquals(Set.of("Kfir Notro"), values.get());
+
+        nested.set(Observable.mutable("apartium"));
+        assertEquals(Set.of("apartium"), values.get());
+    }
+
+    @Test
+    void flatMapEachThenFilterChain() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<String> startsWithA = set
+                .flatMapEach(Member::displayName)
+                .filter(name -> Observable.immutable(name.startsWith("a")));
+
+        assertEquals(Set.of("apartium"), startsWithA.get());
+
+        kfir.displayName().set("aaaa-kfir");
+        assertEquals(Set.of("apartium", "aaaa-kfir"), startsWithA.get());
+    }
+
+    @Test
+    void flatMapEachUnsupportedMutationsThrow() {
+        SetObservable<Member> base = Observable.set();
+        SetObservable<String> mapped = base.flatMapEach(Member::displayName);
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.add("x"));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.remove("x"));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, mapped::clear);
+    }
+
+    @Test
+    void flatMapEachReAddingElementAfterClearWorks() {
+        Member kfir = new Member("kfir");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir)));
+
+        SetObservable<String> names = set.flatMapEach(Member::displayName);
+        assertEquals(Set.of("kfir"), names.get());
+
+        set.clear();
+        assertEquals(Set.of(), names.get());
+
+        set.add(kfir);
+        assertEquals(Set.of("kfir"), names.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(Set.of("Kfir Notro"), names.get());
+    }
+
+    @Test
+    void flatMapEachWithNullMapperResultProducesNullValueWhenCollectionAllows() {
+        Member kfir = new Member("kfir");
+        SetObservable<Member> set = Observable.set(
+                new HashSet<>(Set.of(kfir)),
+                col -> {
+                    Set<Member> copy = new HashSet<>();
+                    copy.addAll(col);
+                    return Collections.unmodifiableSet(copy);
+                },
+                HashSet::new
+        );
+
+        // mapper returning null observable — exercises the `inner == null` branch
+        SetObservable<String> names = set.flatMapEach(member -> null);
+
+        Set<String> snapshot = names.get();
+        assertEquals(1, snapshot.size());
+        assertTrue(snapshot.contains(null));
+
+        // even after a base change, removing a null-mapped element must not crash
+        set.remove(kfir);
+        assertEquals(Set.of(), names.get());
+    }
+
+    // ---------------------------------------------------------------------
+    // filter edge cases
+    // ---------------------------------------------------------------------
+
+    @Test
+    void filterOnEmptySet() {
+        SetObservable<String> set = Observable.set();
+        SetObservable<String> filtered = set.filter(s -> Observable.immutable(true));
+
+        assertEquals(Set.of(), filtered.get());
+        assertEquals(0, filtered.size().get());
+    }
+
+    @Test
+    void filterAllTrueReturnsEverything() {
+        SetObservable<String> set = Observable.set(new HashSet<>(Set.of("kfir", "apartium", "voigon")));
+        SetObservable<String> filtered = set.filter(s -> Observable.immutable(true));
+
+        assertEquals(Set.of("kfir", "apartium", "voigon"), filtered.get());
+    }
+
+    @Test
+    void filterAllFalseReturnsEmpty() {
+        SetObservable<String> set = Observable.set(new HashSet<>(Set.of("kfir", "apartium")));
+        SetObservable<String> filtered = set.filter(s -> Observable.immutable(false));
+
+        assertEquals(Set.of(), filtered.get());
+    }
+
+    @Test
+    void filterTogglingPredicateAddsAndRemovesElement() {
+        Member kfir = new Member("kfir");
+        kfir.active().set(true);
+        Member lior = new Member("lior");
+        lior.active().set(false);
+
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, lior)));
+        SetObservable<Member> active = set.filter(Member::active);
+
+        assertEquals(Set.of(kfir), active.get());
+
+        // false -> true exercises updateElements value=true && !contains
+        lior.active().set(true);
+        assertEquals(Set.of(kfir, lior), active.get());
+
+        // true -> false exercises updateElements value=false && contains
+        kfir.active().set(false);
+        assertEquals(Set.of(lior), active.get());
+
+        // toggle no-op (already false): MutableObservable.set short-circuits, no notification at all
+        kfir.active().set(false);
+        assertEquals(Set.of(lior), active.get());
+    }
+
+    @Test
+    void filterAddingElementWithTruePredicateIncludesIt() {
+        SetObservable<Member> set = Observable.set();
+        SetObservable<Member> active = set.filter(Member::active);
+
+        assertEquals(Set.of(), active.get());
+
+        Member kfir = new Member("kfir");
+        kfir.active().set(true);
+        set.add(kfir);
+        assertEquals(Set.of(kfir), active.get());
+    }
+
+    @Test
+    void filterAddingElementWithFalsePredicateExcludesIt() {
+        SetObservable<Member> set = Observable.set();
+        SetObservable<Member> active = set.filter(Member::active);
+
+        assertEquals(Set.of(), active.get());
+
+        Member kfir = new Member("kfir");
+        kfir.active().set(false);
+        set.add(kfir);
+        assertEquals(Set.of(), active.get());
+
+        kfir.active().set(true);
+        assertEquals(Set.of(kfir), active.get());
+    }
+
+    @Test
+    void filterRemovingElementRemovesItFromResult() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<Member> active = set.filter(Member::active);
+        assertEquals(Set.of(kfir, apartium), active.get());
+
+        set.remove(kfir);
+        assertEquals(Set.of(apartium), active.get());
+    }
+
+    @Test
+    void filterChainedFilter() {
+        SetObservable<Integer> set = Observable.set(new HashSet<>(Set.of(1, 2, 3, 4, 5, 6, 7, 8)));
+
+        SetObservable<Integer> evenAndLarge = set
+                .filter(n -> Observable.immutable(n % 2 == 0))
+                .filter(n -> Observable.immutable(n >= 4));
+
+        assertEquals(Set.of(4, 6, 8), evenAndLarge.get());
+    }
+
+    @Test
+    void filterThenMapEach() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<String> activeIds = set
+                .filter(Member::active)
+                .mapEach(Member::id);
+
+        assertEquals(Set.of("kfir", "apartium"), activeIds.get());
+    }
+
+    @Test
+    void filterThenFlatMapEach() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        apartium.active().set(false);
+
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<String> activeNames = set
+                .filter(Member::active)
+                .flatMapEach(Member::displayName);
+
+        assertEquals(Set.of("kfir"), activeNames.get());
+
+        kfir.displayName().set("Kfir Notro");
+        assertEquals(Set.of("Kfir Notro"), activeNames.get());
+
+        apartium.active().set(true);
+        assertEquals(Set.of("Kfir Notro", "apartium"), activeNames.get());
+    }
+
+    @Test
+    void filterCachedWhenNoNetChange() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+
+        SetObservable<Member> active = set.filter(Member::active);
+        Set<Member> initial = active.get();
+        assertEquals(Set.of(kfir, apartium), initial);
+
+        // toggle false -> true means two flagAsDirty events but the final value is unchanged
+        kfir.active().set(false);
+        kfir.active().set(true);
+        Set<Member> after = active.get();
+        assertEquals(initial, after, "net-zero toggle must produce the same membership");
+
+        assertSame(after, active.get(), "second get() with no further changes must return the same cached snapshot");
+    }
+
+    @Test
+    void filterIgnoresFlagAsDirtyFromUnrelatedObservable() {
+        Member kfir = new Member("kfir");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir)));
+        SetObservable<Member> active = set.filter(Member::active);
+        active.get();
+
+        CountingObserver downstream = new CountingObserver();
+        active.observe(downstream);
+
+        Observer asObserver = (Observer) active;
+        MutableObservable<Boolean> unrelated = Observable.mutable(true);
+        asObserver.flagAsDirty(unrelated);
+
+        assertEquals(0, downstream.count, "unrelated observable must not trigger filter notifications");
+    }
+
+    @Test
+    void filterSizeReflectsFilteredCount() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        Member voigon = new Member("voigon");
+        voigon.active().set(false);
+
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium, voigon)));
+        SetObservable<Member> active = set.filter(Member::active);
+
+        assertEquals(2, active.size().get());
+
+        voigon.active().set(true);
+        assertEquals(3, active.size().get());
+
+        set.clear();
+        assertEquals(0, active.size().get());
+    }
+
+    @Test
+    void filterTwoArgOverloadMapsThenTests() {
+        Member kfir = new Member("kfir");
+        Member lior = new Member("lior");
+        Member apartium = new Member("apartium");
+
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, lior, apartium)));
+
+        // filter(mapper, predicate) — uses the inner mapper to a String, then tests
+        SetObservable<Member> startsWithVowel = set.filter(
+                Member::displayName,
+                name -> "aeiou".indexOf(name.charAt(0)) >= 0
+        );
+
+        assertEquals(Set.of(apartium), startsWithVowel.get());
+
+        kfir.displayName().set("orion");
+        assertEquals(Set.of(apartium, kfir), startsWithVowel.get());
+    }
+
+    @Test
+    void filterUnsupportedMutationsThrow() {
+        SetObservable<Integer> filtered = Observable.<Integer>set().filter(n -> Observable.immutable(true));
+
+        assertThrows(UnsupportedOperationException.class, () -> filtered.add(1));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.remove(1));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.addAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.removeAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.removeIf(n -> true));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, filtered::clear);
+    }
+
+    @Test
+    void filterRemovingElementWhileShufflingPredicate() {
+        // Exercise the path where checkAndUpdateBase rebuilds dependsOn after a base change
+        // while previously toggled flags need to be discarded.
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        Member voigon = new Member("voigon");
+
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium, voigon)));
+        SetObservable<Member> active = set.filter(Member::active);
+
+        assertEquals(Set.of(kfir, apartium, voigon), active.get());
+
+        // toggle a flag, then change the base before the next get()
+        voigon.active().set(false);
+        set.remove(apartium);
+
+        // checkAndUpdateBase should run because base changed; flagged state for voigon is cleared
+        assertEquals(Set.of(kfir), active.get());
+    }
+
+    @Test
+    void filterUpdatePathHandlesIncrementalToggleWithoutRebuildingBase() {
+        Member kfir = new Member("kfir");
+        Member apartium = new Member("apartium");
+        SetObservable<Member> set = Observable.set(new HashSet<>(Set.of(kfir, apartium)));
+        SetObservable<Member> active = set.filter(Member::active);
+
+        // initial materialization populates cacheValueMap and dependsOn
+        assertEquals(Set.of(kfir, apartium), active.get());
+
+        // a single inner toggle exercises updateFlagged (base unchanged)
+        kfir.active().set(false);
+        assertEquals(Set.of(apartium), active.get());
+
+        kfir.active().set(true);
+        assertEquals(Set.of(kfir, apartium), active.get());
+    }
+
+    @Test
+    void filterSharedFilterObservableForMultipleElements() {
+        // two distinct elements share the same filter Observable (immutable singleton-ish)
+        // so filter.apply must group them under the same key in dependsOn.
+        Observable<Boolean> alwaysTrue = Observable.immutable(true);
+
+        SetObservable<String> set = Observable.set(new HashSet<>(Set.of("kfir", "apartium", "voigon")));
+        SetObservable<String> filtered = set.filter(name -> alwaysTrue);
+
+        assertEquals(Set.of("kfir", "apartium", "voigon"), filtered.get());
+
+        set.add("notro");
+        assertEquals(Set.of("kfir", "apartium", "voigon", "notro"), filtered.get());
+
+        set.remove("kfir");
+        assertEquals(Set.of("apartium", "voigon", "notro"), filtered.get());
+    }
+
+    @Test
+    void filterOnLinkedHashSetPreservesInsertionOrder() {
+        SetObservable<String> set = Observable.set(
+                new LinkedHashSet<>(),
+                col -> Collections.unmodifiableSet(new LinkedHashSet<>(col)),
+                LinkedHashSet::new
+        );
+        set.add("kfir");
+        set.add("apartium");
+        set.add("voigon");
+        set.add("lior");
+
+        SetObservable<String> filtered = set.filter(name -> Observable.immutable(name.length() <= 5));
+
+        List<String> ordered = new ArrayList<>(filtered.get());
+        assertEquals(List.of("kfir", "lior"), ordered);
+    }
+
+    // ---------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------
+
+    private record Member(
+            String id,
+            MutableObservable<String> displayName,
+            MutableObservable<Boolean> active
+    ) {
+
+        Member(String id) {
+            this(id, Observable.mutable(id), Observable.mutable(true));
+        }
+
+        Member(String id, MutableObservable<String> displayName) {
+            this(id, displayName, Observable.mutable(true));
+        }
+
+    }
+
+    private static final class CountingObserver implements Observer {
+
+        int count;
+        Observable<?> last;
+
+        @Override
+        public void flagAsDirty(Observable<?> observable) {
+            count++;
+            last = observable;
+        }
+
     }
 
 }

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/SetObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/SetObservableTest.java
@@ -271,6 +271,64 @@ class SetObservableTest {
     }
 
     @Test
+    void customCopyOfPropagatesThroughMapEach() {
+        // Type-erased custom factories (LinkedHashSet, etc.) propagate to mapEach views.
+        // The cast in SetObservableImpl.mapEach is safe for factories that don't capture
+        // element-type-specific state.
+        AtomicInteger copyOfCallCount = new AtomicInteger();
+        AtomicInteger createInitCallCount = new AtomicInteger();
+
+        Set<Integer> backing = new LinkedHashSet<>();
+        SetObservable<Integer> set = Observable.set(
+                backing,
+                col -> {
+                    copyOfCallCount.incrementAndGet();
+                    return new LinkedHashSet<>(col);
+                },
+                cap -> {
+                    createInitCallCount.incrementAndGet();
+                    return new LinkedHashSet<>(cap);
+                }
+        );
+
+        set.add(3);
+        set.add(1);
+        set.add(2);
+
+        SetObservable<String> mapped = set.mapEach(n -> "n=" + n);
+        Set<String> snapshot = mapped.get();
+
+        assertInstanceOf(LinkedHashSet.class, snapshot,
+                "user-supplied LinkedHashSet copyOf must be reused through mapEach");
+        assertEquals(List.of("n=3", "n=1", "n=2"), new ArrayList<>(snapshot),
+                "insertion order is preserved across mapEach");
+        assertTrue(copyOfCallCount.get() > 0, "user copyOf must have been invoked for the mapped view");
+        assertTrue(createInitCallCount.get() > 0, "user createInitSet must have been invoked for the mapped view");
+    }
+
+    @Test
+    void customCopyOfPropagatesThroughFlatMapEach() {
+        Set<Integer> backing = new LinkedHashSet<>();
+        SetObservable<Integer> set = Observable.set(
+                backing,
+                LinkedHashSet::new,
+                LinkedHashSet::new
+        );
+
+        set.add(10);
+        set.add(20);
+        set.add(30);
+
+        SetObservable<String> mapped = set.flatMapEach(n -> Observable.immutable("v=" + n));
+        Set<String> snapshot = mapped.get();
+
+        assertInstanceOf(LinkedHashSet.class, snapshot,
+                "user-supplied LinkedHashSet factory must propagate through flatMapEach");
+        assertEquals(List.of("v=10", "v=20", "v=30"), new ArrayList<>(snapshot),
+                "insertion order is preserved across flatMapEach");
+    }
+
+    @Test
     void customCopyOfPropagatesThroughChainedFilters() {
         AtomicInteger copyOfCallCount = new AtomicInteger(0);
         Set<Integer> backing = new HashSet<>();

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/SetObservableTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/SetObservableTest.java
@@ -533,10 +533,13 @@ class SetObservableTest {
 
         assertThrows(UnsupportedOperationException.class, () -> mapped.add(1));
         assertThrows(UnsupportedOperationException.class, () -> mapped.remove(1));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+
+        List<Integer> collection = List.of();
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(collection));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(collection));
         assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(collection));
         assertThrows(UnsupportedOperationException.class, mapped::clear);
     }
 
@@ -821,10 +824,13 @@ class SetObservableTest {
 
         assertThrows(UnsupportedOperationException.class, () -> mapped.add("x"));
         assertThrows(UnsupportedOperationException.class, () -> mapped.remove("x"));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(List.of()));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(List.of()));
+
+        List<String> collection = List.of();
+
+        assertThrows(UnsupportedOperationException.class, () -> mapped.addAll(collection));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.removeAll(collection));
         assertThrows(UnsupportedOperationException.class, () -> mapped.removeIf(n -> true));
-        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> mapped.retainAll(collection));
         assertThrows(UnsupportedOperationException.class, mapped::clear);
     }
 
@@ -1093,10 +1099,13 @@ class SetObservableTest {
 
         assertThrows(UnsupportedOperationException.class, () -> filtered.add(1));
         assertThrows(UnsupportedOperationException.class, () -> filtered.remove(1));
-        assertThrows(UnsupportedOperationException.class, () -> filtered.addAll(List.of()));
-        assertThrows(UnsupportedOperationException.class, () -> filtered.removeAll(List.of()));
+
+        List<Integer> collection = List.of();
+
+        assertThrows(UnsupportedOperationException.class, () -> filtered.addAll(collection));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.removeAll(collection));
         assertThrows(UnsupportedOperationException.class, () -> filtered.removeIf(n -> true));
-        assertThrows(UnsupportedOperationException.class, () -> filtered.retainAll(List.of()));
+        assertThrows(UnsupportedOperationException.class, () -> filtered.retainAll(collection));
         assertThrows(UnsupportedOperationException.class, filtered::clear);
     }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation)
- [x] 🐞 Bug fix (fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

This PR improves collection manipulation utilities for `CollectionObservable`.

Changes include:

- Ensures `CollectionObservable#filter` returns results in a consistent order.
- Adds `CollectionObservable#mapEach` for live per-element transformations of observable collections.
- Adds `CollectionObservable#flatMapEach` for live per-element mapping to inner observables.

These changes make collection-derived observables more predictable and easier to compose, especially when working with dynamic collections whose elements may update over time.

Closes #326 
Closes #365 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?
Unit testing

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mapEach and flatMapEach operators for observable collections (lazy, cached per-element transforms and flattened inner-observable mapping); filter now documents a consistent ordering guarantee.

* **Documentation**
  * Added comprehensive guides, examples, and collection-type notes describing mapping, flat-mapping, filtering, subscription semantics, and deduplication behavior.

* **Tests**
  * Large new test suites and samples validating mapEach, flatMapEach, filter behaviors, caching, notification semantics, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->