### PR TITLE
[state] AttachedWatcher reattach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.0.52
+- [state] Add `WatcherOperator#attach` to allow re-attaching a detached watcher to a new operator
+
 ## 0.0.51
 - [commands] Add prioritization for tab completions
 - [commands] Keywords will now be prioritized in tab completion

--- a/Writerside/topics/watcher.md
+++ b/Writerside/topics/watcher.md
@@ -8,3 +8,17 @@ After we have made our reactive state its time to put the final piece in the puz
 Watchers allow us trigger external operations when the state changes.
 
 <code-block lang="java" src="state/CodeSnippets.java" include-symbol="watch"/>
+
+## Re-attaching Watchers {id="re-attaching-watchers"}
+
+<sup>
+Available Since 0.0.52
+</sup>
+
+An `AttachedWatcher` can be detached from its current operator and re-attached to a different one.
+This is useful when you need to move a watcher between managers, for example when transferring ownership of a game loop or switching execution contexts.
+
+Once detached, the watcher will no longer be triggered by the original operator's heartbeat.
+After re-attaching to a new operator, the watcher will respond to the new operator's heartbeat instead.
+
+<code-block lang="java" src="state/CodeSnippets.java" include-symbol="reAttachWatcher"/>

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AttachedWatcher.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AttachedWatcher.java
@@ -35,8 +35,23 @@ public abstract class AttachedWatcher<T> extends Watcher<T> {
         Ensures.notNull(manager, "manager +-");
 
         this.manager = manager;
-        this.manager.attach(this);
-        depends.observe(this);
+        boolean registered = false;
+        try {
+            this.manager.attach(this);
+            registered = true;
+            depends.observe(this);
+        } catch (RuntimeException e) {
+            if (registered) {
+                try {
+                    this.manager.detach(this);
+                } catch (RuntimeException suppressed) {
+                    e.addSuppressed(suppressed);
+                }
+            }
+
+            this.manager = null;
+            throw e;
+        }
     }
 
     /**

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AttachedWatcher.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AttachedWatcher.java
@@ -35,6 +35,7 @@ public abstract class AttachedWatcher<T> extends Watcher<T> {
         Ensures.notNull(manager, "manager +-");
 
         this.manager = manager;
+        this.manager.attach(this);
         depends.observe(this);
     }
 

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AttachedWatcher.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/AttachedWatcher.java
@@ -52,6 +52,8 @@ public abstract class AttachedWatcher<T> extends Watcher<T> {
             this.manager = null;
             throw e;
         }
+
+        this.isDirty = true;
     }
 
     /**

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Watcher.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/Watcher.java
@@ -15,9 +15,9 @@ import java.util.Objects;
 public abstract class Watcher<T> implements Observer {
 
     protected final Observable<T> depends;
-    private boolean first = true;
-    private boolean isDirty = true;
-    private T prevValue;
+    protected boolean first = true;
+    protected boolean isDirty = true;
+    protected T prevValue;
 
     /**
      * Constructs a new instance

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/WatcherManager.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/WatcherManager.java
@@ -56,14 +56,27 @@ public class WatcherManager implements WatcherOperator {
                 consumer.accept(newValue);
             }
         };
+
+        watcher.attach(this);
+        return watcher;
+    }
+
+    /**
+     * Attaches a watcher to the current instance
+     * @param watcher watcher to attach
+     */
+    @ApiStatus.AvailableSince("0.0.52")
+    @Override
+    public void attach(AttachedWatcher<?> watcher) {
+        if (watcher.getManager() != this)
+            throw new IllegalArgumentException("Not attached to this manager");
+
         lock.writeLock().lock();
         try {
             watchers.add(watcher);
         } finally {
             lock.writeLock().unlock();
         }
-        watcher.attach(this);
-        return watcher;
     }
 
     /**

--- a/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/WatcherOperator.java
+++ b/cocoa-beans-state/src/main/java/net/apartium/cocoabeans/state/WatcherOperator.java
@@ -11,6 +11,18 @@ import org.jetbrains.annotations.ApiStatus;
 public interface WatcherOperator {
 
     /**
+     * Attach a watcher to the current operator.
+     * This method is called by {@link AttachedWatcher#attach(WatcherOperator)} to register
+     * the watcher with the operator so it will be included in future heartbeat cycles.
+     *
+     * @param watcher the watcher to attach
+     * @throws IllegalArgumentException if the watcher is not associated with this operator
+     * @see AttachedWatcher#attach(WatcherOperator)
+     */
+    @ApiStatus.AvailableSince("0.0.52")
+    void attach(AttachedWatcher<?> watcher);
+
+    /**
      * Detach a watcher attached with the current instance
      * @param watcher watcher instance
      */

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
@@ -2,6 +2,8 @@ package net.apartium.cocoabeans.state;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class AttachedWatcherTest {
@@ -16,7 +18,17 @@ class AttachedWatcherTest {
             }
         };
 
-        WatcherOperator operator = w -> {};
+        WatcherOperator operator = new WatcherOperator() {
+            @Override
+            public void attach(AttachedWatcher<?> watcher) {
+
+            }
+
+            @Override
+            public void detach(AttachedWatcher<?> watcher) {
+
+            }
+        };
 
         watcher.attach(operator);
 
@@ -38,7 +50,17 @@ class AttachedWatcherTest {
             }
         };
 
-        WatcherOperator operator = w -> {};
+        WatcherOperator operator = new WatcherOperator() {
+            @Override
+            public void attach(AttachedWatcher<?> watcher) {
+
+            }
+
+            @Override
+            public void detach(AttachedWatcher<?> watcher) {
+
+            }
+        };
 
         watcher.attach(operator);
 
@@ -58,6 +80,96 @@ class AttachedWatcherTest {
             }
         };
         assertThrowsExactly(IllegalArgumentException.class, watcher::detach);
+    }
+
+    @Test
+    void reAttachToDifferentOperator() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        AtomicInteger callCount = new AtomicInteger();
+        AttachedWatcher<Integer> watcher = new AttachedWatcher<>(num) {
+            @Override
+            public void onChange(Integer newValue) {
+                callCount.incrementAndGet();
+            }
+        };
+
+        WatcherManager firstManager = new WatcherManager();
+        WatcherManager secondManager = new WatcherManager();
+
+        watcher.attach(firstManager);
+        assertTrue(watcher.isAttached());
+        assertEquals(firstManager, watcher.getManager());
+
+        // heartbeat on first manager triggers the watcher
+        firstManager.heartbeat();
+        assertEquals(1, callCount.get());
+
+        num.set(10);
+        firstManager.heartbeat();
+        assertEquals(2, callCount.get());
+
+        // detach from first manager
+        watcher.detach();
+        assertFalse(watcher.isAttached());
+        assertNull(watcher.getManager());
+
+        // heartbeat on first manager should no longer trigger
+        num.set(20);
+        firstManager.heartbeat();
+        assertEquals(2, callCount.get());
+
+        // re-attach to second manager
+        watcher.attach(secondManager);
+        assertTrue(watcher.isAttached());
+        assertEquals(secondManager, watcher.getManager());
+
+        // changes while detached are not observed, so set a new value
+        num.set(25);
+        secondManager.heartbeat();
+        assertEquals(3, callCount.get());
+
+        num.set(30);
+        secondManager.heartbeat();
+        assertEquals(4, callCount.get());
+
+        // first manager still does not trigger
+        num.set(40);
+        firstManager.heartbeat();
+        assertEquals(4, callCount.get());
+
+        watcher.detach();
+        assertFalse(watcher.isAttached());
+    }
+
+    @Test
+    void reAttachToSameOperator() {
+        MutableObservable<Integer> num = Observable.mutable(1);
+        AtomicInteger callCount = new AtomicInteger();
+        AttachedWatcher<Integer> watcher = new AttachedWatcher<>(num) {
+            @Override
+            public void onChange(Integer newValue) {
+                callCount.incrementAndGet();
+            }
+        };
+
+        WatcherManager manager = new WatcherManager();
+
+        watcher.attach(manager);
+        manager.heartbeat();
+        assertEquals(1, callCount.get());
+
+        watcher.detach();
+
+        // re-attach to the same manager
+        watcher.attach(manager);
+        assertTrue(watcher.isAttached());
+        assertEquals(manager, watcher.getManager());
+
+        num.set(42);
+        manager.heartbeat();
+        assertEquals(2, callCount.get());
+
+        watcher.detach();
     }
 
 }

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class AttachedWatcherTest {
@@ -39,6 +42,142 @@ class AttachedWatcherTest {
         watcher.detach();
 
         assertFalse(watcher.isAttached());
+    }
+
+    @Test
+    void watcherIsAttachedAfterCreation() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        List<Integer> changes = new ArrayList<>();
+        WatcherManager operator = new WatcherManager();
+
+        AttachedWatcher<Integer> watcher = operator.watch(num, changes::add);
+
+        assertTrue(watcher.isAttached());
+        assertEquals(operator, watcher.getManager());
+        assertTrue(changes.isEmpty());
+    }
+
+    @Test
+    void firstHeartbeatPublishesInitialValue() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        List<Integer> changes = new ArrayList<>();
+        WatcherManager operator = new WatcherManager();
+
+        operator.watch(num, changes::add);
+        operator.heartbeat();
+
+        assertEquals(List.of(5), changes);
+    }
+
+    @Test
+    void repeatedHeartbeatsDoNotPublishUnchangedValue() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        List<Integer> changes = new ArrayList<>();
+        WatcherManager operator = new WatcherManager();
+
+        operator.watch(num, changes::add);
+        operator.heartbeat();
+        changes.clear();
+
+        for (int i = 0; i < 10; i++) {
+            operator.heartbeat();
+            assertTrue(changes.isEmpty());
+        }
+    }
+
+    @Test
+    void changedValueIsPublishedOnHeartbeat() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        List<Integer> changes = new ArrayList<>();
+        WatcherManager operator = new WatcherManager();
+
+        operator.watch(num, changes::add);
+        operator.heartbeat();
+        changes.clear();
+
+        num.set(15);
+
+        assertTrue(changes.isEmpty());
+
+        operator.heartbeat();
+
+        assertEquals(List.of(15), changes);
+    }
+
+    @Test
+    void detachedWatcherDoesNotPublishChanges() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        List<Integer> changes = new ArrayList<>();
+        WatcherManager operator = new WatcherManager();
+
+        AttachedWatcher<Integer> watcher = operator.watch(num, changes::add);
+
+        operator.heartbeat();
+        changes.clear();
+
+        watcher.detach();
+
+        assertFalse(watcher.isAttached());
+
+        operator.heartbeat();
+        assertTrue(changes.isEmpty());
+
+        num.set(20);
+        assertTrue(changes.isEmpty());
+
+        operator.heartbeat();
+        assertTrue(changes.isEmpty());
+    }
+
+    @Test
+    void reattachedWatcherPublishesCurrentValue() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        List<Integer> changes = new ArrayList<>();
+        WatcherManager operator = new WatcherManager();
+
+        AttachedWatcher<Integer> watcher = operator.watch(num, changes::add);
+
+        operator.heartbeat();
+        changes.clear();
+
+        watcher.detach();
+        num.set(20);
+
+        watcher.attach(operator);
+
+        assertTrue(changes.isEmpty());
+
+        operator.heartbeat();
+
+        assertEquals(List.of(20), changes);
+    }
+
+    @Test
+    void reattachedWatcherDoesNotPublishWhenValueReturnsToLastPublishedValue() {
+        MutableObservable<Integer> num = Observable.mutable(5);
+        List<Integer> changes = new ArrayList<>();
+        WatcherManager operator = new WatcherManager();
+
+        AttachedWatcher<Integer> watcher = operator.watch(num, changes::add);
+
+        operator.heartbeat();
+
+        num.set(20);
+        operator.heartbeat();
+        changes.clear();
+
+        watcher.detach();
+
+        num.set(15);
+        num.set(20);
+
+        watcher.attach(operator);
+
+        assertTrue(changes.isEmpty());
+
+        operator.heartbeat();
+
+        assertTrue(changes.isEmpty());
     }
 
     @Test

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
@@ -2,6 +2,7 @@ package net.apartium.cocoabeans.state;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,12 +22,12 @@ class AttachedWatcherTest {
         WatcherOperator operator = new WatcherOperator() {
             @Override
             public void attach(AttachedWatcher<?> watcher) {
-
+                /* ignore */
             }
 
             @Override
             public void detach(AttachedWatcher<?> watcher) {
-
+                /* ignore */
             }
         };
 
@@ -53,12 +54,12 @@ class AttachedWatcherTest {
         WatcherOperator operator = new WatcherOperator() {
             @Override
             public void attach(AttachedWatcher<?> watcher) {
-
+                /* ignore */
             }
 
             @Override
             public void detach(AttachedWatcher<?> watcher) {
-
+                /* ignore */
             }
         };
 
@@ -80,6 +81,161 @@ class AttachedWatcherTest {
             }
         };
         assertThrowsExactly(IllegalArgumentException.class, watcher::detach);
+    }
+
+    @Test
+    void attachWithNullManager() {
+        Observable<Integer> num = Observable.mutable(5);
+        AttachedWatcher<Integer> watcher = new AttachedWatcher<>(num) {
+            @Override
+            public void onChange(Integer newValue) {
+            }
+        };
+
+        assertThrowsExactly(NullPointerException.class, () -> watcher.attach(null));
+        assertFalse(watcher.isAttached());
+        assertNull(watcher.getManager());
+    }
+
+    @Test
+    void attachRollsBackWhenOperatorAttachThrows() {
+        Observable<Integer> num = Observable.mutable(5);
+        AttachedWatcher<Integer> watcher = new AttachedWatcher<>(num) {
+            @Override
+            public void onChange(Integer newValue) {
+            }
+        };
+
+        WatcherOperator failingOperator = new WatcherOperator() {
+            @Override
+            public void attach(AttachedWatcher<?> watcher) {
+                throw new RuntimeException("operator rejected");
+            }
+
+            @Override
+            public void detach(AttachedWatcher<?> watcher) {
+                /* ignore */
+            }
+        };
+
+        RuntimeException ex = assertThrowsExactly(RuntimeException.class, () -> watcher.attach(failingOperator));
+        assertEquals("operator rejected", ex.getMessage());
+
+        // watcher should be rolled back to unattached state
+        assertFalse(watcher.isAttached());
+        assertNull(watcher.getManager());
+
+        // should still be attachable after the failed attempt
+        WatcherManager manager = new WatcherManager();
+        watcher.attach(manager);
+        assertTrue(watcher.isAttached());
+        assertEquals(manager, watcher.getManager());
+        watcher.detach();
+    }
+
+    @Test
+    void attachRollsBackWhenObserveThrows() {
+        AtomicBoolean shouldThrow = new AtomicBoolean(false);
+        AtomicBoolean detachCalled = new AtomicBoolean(false);
+
+        Observable<Integer> throwingObservable = new Observable<>() {
+            @Override
+            public Integer get() {
+                return 0;
+            }
+
+            @Override
+            public void observe(Observer observer) {
+                if (shouldThrow.get())
+                    throw new RuntimeException("observe failed");
+            }
+
+            @Override
+            public boolean removeObserver(Observer observer) {
+                return true;
+            }
+        };
+
+        AttachedWatcher<Integer> watcher = new AttachedWatcher<>(throwingObservable) {
+            @Override
+            public void onChange(Integer newValue) {
+            }
+        };
+
+        WatcherOperator operator = new WatcherOperator() {
+            @Override
+            public void attach(AttachedWatcher<?> watcher) {
+                /* accept */
+            }
+
+            @Override
+            public void detach(AttachedWatcher<?> watcher) {
+                detachCalled.set(true);
+            }
+        };
+
+        // observe throws after operator.attach succeeds → should rollback by calling operator.detach
+        shouldThrow.set(true);
+        RuntimeException ex = assertThrowsExactly(RuntimeException.class, () -> watcher.attach(operator));
+        assertEquals("observe failed", ex.getMessage());
+
+        // operator.detach was called to rollback
+        assertTrue(detachCalled.get());
+
+        // watcher is not attached
+        assertFalse(watcher.isAttached());
+        assertNull(watcher.getManager());
+    }
+
+    @Test
+    void attachRollbackDetachThrowsSuppressed() {
+        AtomicBoolean shouldThrow = new AtomicBoolean(false);
+
+        Observable<Integer> throwingObservable = new Observable<>() {
+            @Override
+            public Integer get() {
+                return 0;
+            }
+
+            @Override
+            public void observe(Observer observer) {
+                if (shouldThrow.get())
+                    throw new RuntimeException("observe failed");
+            }
+
+            @Override
+            public boolean removeObserver(Observer observer) {
+                return true;
+            }
+        };
+
+        AttachedWatcher<Integer> watcher = new AttachedWatcher<>(throwingObservable) {
+            @Override
+            public void onChange(Integer newValue) {
+            }
+        };
+
+        WatcherOperator operator = new WatcherOperator() {
+            @Override
+            public void attach(AttachedWatcher<?> watcher) {
+                /* accept */
+            }
+
+            @Override
+            public void detach(AttachedWatcher<?> watcher) {
+                throw new RuntimeException("detach also failed");
+            }
+        };
+
+        // observe throws, then rollback detach also throws → detach exception is suppressed
+        shouldThrow.set(true);
+        RuntimeException ex = assertThrowsExactly(RuntimeException.class, () -> watcher.attach(operator));
+        assertEquals("observe failed", ex.getMessage());
+        assertEquals(1, ex.getSuppressed().length);
+        assertEquals("detach also failed", ex.getSuppressed()[0].getMessage());
+
+        assertFalse(watcher.isAttached());
+        assertNull(watcher.getManager());
     }
 
     @Test

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/AttachedWatcherTest.java
@@ -89,6 +89,7 @@ class AttachedWatcherTest {
         AttachedWatcher<Integer> watcher = new AttachedWatcher<>(num) {
             @Override
             public void onChange(Integer newValue) {
+                /* ignore */
             }
         };
 
@@ -103,6 +104,7 @@ class AttachedWatcherTest {
         AttachedWatcher<Integer> watcher = new AttachedWatcher<>(num) {
             @Override
             public void onChange(Integer newValue) {
+                /* ignore */
             }
         };
 
@@ -159,6 +161,7 @@ class AttachedWatcherTest {
         AttachedWatcher<Integer> watcher = new AttachedWatcher<>(throwingObservable) {
             @Override
             public void onChange(Integer newValue) {
+                /* ignore */
             }
         };
 
@@ -212,6 +215,7 @@ class AttachedWatcherTest {
         AttachedWatcher<Integer> watcher = new AttachedWatcher<>(throwingObservable) {
             @Override
             public void onChange(Integer newValue) {
+                /* ignore */
             }
         };
 

--- a/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/CodeSnippets.java
+++ b/cocoa-beans-state/src/test/java/net/apartium/cocoabeans/state/CodeSnippets.java
@@ -573,6 +573,49 @@ class CodeSnippets {
     }
 
     @Test
+    void reAttachWatcher() {
+        MutableObservable<Integer> observable = Observable.mutable(1);
+        AtomicInteger count = new AtomicInteger();
+
+        WatcherManager firstManager = new WatcherManager();
+        WatcherManager secondManager = new WatcherManager();
+
+        AttachedWatcher<Integer> watcher = observable.lazyWatch(firstManager, num -> {
+            count.incrementAndGet();
+        });
+
+        // watcher reacts to the first manager's heartbeat
+        firstManager.heartbeat();
+        assertEquals(1, count.get());
+
+        observable.set(10);
+        firstManager.heartbeat();
+        assertEquals(2, count.get());
+
+        // detach from the first manager
+        watcher.detach();
+
+        // first manager no longer triggers the watcher
+        observable.set(20);
+        firstManager.heartbeat();
+        assertEquals(2, count.get());
+
+        // re-attach to a different manager
+        watcher.attach(secondManager);
+
+        // now the second manager drives the watcher
+        observable.set(25);
+        secondManager.heartbeat();
+        assertEquals(3, count.get());
+
+        observable.set(30);
+        secondManager.heartbeat();
+        assertEquals(4, count.get());
+
+        watcher.detach();
+    }
+
+    @Test
     void sortedObservableComparatorSample() {
         ListObservable<Integer> scores = Observable.list();
         scores.addAll(List.of(3, 1, 4, 1, 5, 9));


### PR DESCRIPTION


<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation)
- [ ] 🐞 Bug fix (fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description
Closes #387
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?
Unit test
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watchers can now be detached and re-attached to another operator, so heartbeat updates continue from the new source.
  * Added example snippet demonstrating re-attachment behavior.
* **Documentation**
  * Updated the watcher guide with a dedicated “Re-attaching Watchers” section and updated “Available Since 0.0.52” notes.
  * Updated the changelog with the new version entry.
* **Bug Fixes**
  * Improved re-attachment reliability, including safer rollback if attachment setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->