### PR TITLE
Add 26.2 to MinecraftVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.53
 - [build] Gradle dependency verification
 - [repo] Fixes for Writerside versions list
+- [common] Add 26.2 to MinecraftVersion
 
 ## 0.0.52
 - [state] Add `WatcherOperator#attach` to allow re-attaching a detached watcher to a new operator

--- a/cocoa-beans-common/src/main/java/net/apartium/cocoabeans/structs/MinecraftVersion.java
+++ b/cocoa-beans-common/src/main/java/net/apartium/cocoabeans/structs/MinecraftVersion.java
@@ -123,6 +123,7 @@ public record MinecraftVersion(
     public static final MinecraftVersion V26_1 = new MinecraftVersion(26, 1, 0, 775);
     public static final MinecraftVersion V26_1_1 = new MinecraftVersion(26, 1, 1, 775);
     public static final MinecraftVersion V26_1_2 = new MinecraftVersion(26, 1, 2, 775);
+    public static final MinecraftVersion V26_2 = new MinecraftVersion(26, 2, 0, 776);
 
     public static final List<MinecraftVersion> KNOWN_VERSIONS = List.of(
             // 1.8 - 1.8.9
@@ -226,7 +227,10 @@ public record MinecraftVersion(
             // 26.1 - 26.1.2
             V26_1,
             V26_1_1,
-            V26_1_2
+            V26_1_2,
+
+            // 26.2
+            V26_2
     );
 
     /**


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation)
- [ ] 🐞 Bug fix (fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Minecraft version 26.2.
  * Added protocol version 776 to the list of recognized Minecraft versions.

* **Documentation**
  * Updated the changelog for version 0.0.53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->